### PR TITLE
fix(paste): paste-depth semantics + shallow queue + HID write guard

### DIFF
--- a/docs/superpowers/plans/2026-04-10-paste-depth-semantics.md
+++ b/docs/superpowers/plans/2026-04-10-paste-depth-semantics.md
@@ -303,6 +303,7 @@ func drainMacroQueue() {
 		// Non-paste macros never touch pasteDepth or emit state.
 		if item.isPaste {
 			if pasteDepth.Add(-1) == 0 {
+				logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 1->0 (drain complete)")
 				emitPasteState(item.session, false)
 			}
 		}
@@ -410,7 +411,9 @@ func cancelAndDrainMacroQueue() {
 		logger.Info().Int("count", discardedTotal).Msg("drained queued keyboard macros")
 	}
 	if discardedPaste > 0 {
+		logger.Debug().Int32("discarded_paste", discardedPaste).Msg("cancel sweep discarded paste macros")
 		if pasteDepth.Add(-discardedPaste) == 0 {
+			logger.Debug().Msg("paste-depth 1->0 (cancel sweep)")
 			emitPasteState(lastPasteSession, false)
 		}
 	}
@@ -461,6 +464,7 @@ func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep,
 	// Emit State:true if this Add is the 0→1 transition.
 	if isPaste {
 		if pasteDepth.Add(1) == 1 {
+			logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 0->1 (enqueue)")
 			emitPasteState(session, true)
 		}
 	}
@@ -475,6 +479,7 @@ func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep,
 	case <-ctx.Done():
 		if isPaste {
 			if pasteDepth.Add(-1) == 0 {
+				logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 1->0 (enqueue rollback)")
 				emitPasteState(session, false)
 			}
 		}
@@ -634,12 +639,15 @@ Replace with:
 	// With the shallow 64-slot macroQueue and blocking backpressure on full,
 	// handleHidRPCMessage can legitimately take longer than the 1-second
 	// timeout below. If we left this unbuffered, the worker would block forever
-	// on `r <- nil` once the timeout fired, leaking a goroutine per timed-out
-	// message.
-	r := make(chan interface{}, 1)
+	// on the done-send once the timeout fired, leaking a goroutine per
+	// timed-out message.
+	//
+	// chan struct{} rather than chan interface{} — the channel is a pure
+	// done-signal, no payload ever flows through it.
+	r := make(chan struct{}, 1)
 	go func() {
 		handleHidRPCMessage(message, session)
-		r <- nil
+		r <- struct{}{}
 	}()
 	select {
 	case <-time.After(1 * time.Second):
@@ -694,8 +702,8 @@ fix(hid): buffer onHidMessage completion channel and downgrade keyboard-macro ti
 
 The onHidMessage worker previously sent into an unbuffered completion
 channel. If the 1-second handler timeout won the race, the worker would
-block forever on `r <- nil` because nothing was reading — a goroutine
-leak per timed-out message.
+block forever on the done-send because nothing was reading — a
+goroutine leak per timed-out message.
 
 This was latent under the 4096-slot queue because enqueue rarely blocked
 longer than 1s. With the new 64-slot queue from the paste-depth change,
@@ -705,6 +713,8 @@ a busy host, so the leak would become measurable.
 Fix:
 - Buffer the completion channel (capacity 1) so the worker's send is
   always non-blocking, even after the timeout branch has taken over.
+- Change the channel type from chan interface{} to chan struct{} to
+  make the "done signal, no payload" intent obvious.
 - Downgrade the timeout log to Debug for TypeKeyboardMacroReport
   messages specifically — a >1s enqueue under backpressure is expected,
   not a fault. Other HID RPC message types still log Warn on timeout.
@@ -896,6 +906,8 @@ Identify the import block and any existing module-scoped constants (so the new h
 
 Add the following block above the `useKeyboard` hook declaration (directly above the `export function useKeyboard(...)` line, or directly above the nearest module-scoped helper already in the file). This helper must live at module scope, NOT inside `useKeyboard`, because it doesn't use React state.
 
+**Critical correctness note — the `seenTrue` latch.** `useHidStore.subscribe((state) => ...)` without a selector fires on **every** store mutation, not just `isPasteInProgress` changes. If we resolved whenever a subscription update arrived with `isPasteInProgress === false`, an unrelated store update (e.g., a keyboard modifier, a USB status flag, any other slice) during the late-start window would resolve the wait early while the backend hasn't yet emitted `State:true`. The helper latches `seenTrue` — "have we ever observed `isPasteInProgress === true` during this wait?" — and only takes the clean-drain exit once we've actually seen a paste become active. This is the difference between "fast-return on false" (wrong) and "transition-true-then-false" (right).
+
 ```typescript
 type PasteDrainMode = "required" | "bestEffort";
 
@@ -912,12 +924,19 @@ const PASTE_DRAIN_DEFAULT_SETTLE_MS = 500;
  * - "required" — rejects on timeout, never takes the arm-window fast path.
  *   Reserved for #38's chunk boundaries in Phase 2. No Phase 1 call sites.
  *
- * The helper subscribes to useHidStore BEFORE checking the current
- * isPasteInProgress value, so a late-arriving backend State:true cannot be
- * missed. In bestEffort mode, if isPasteInProgress is still false after a
- * short arm window, we assume the paste never materialized (zero batches,
- * immediate error, send loop that did nothing) and resolve without waiting
- * for the full timeout.
+ * Correctness: the helper subscribes to useHidStore BEFORE sampling the
+ * current isPasteInProgress value, and latches a local `seenTrue` flag.
+ * The clean-drain exit fires only when the subscription observes
+ * isPasteInProgress transition to false AFTER we've already seen it be
+ * true. Without the latch, any unrelated store mutation arriving while
+ * isPasteInProgress is still in its late-start false window would resolve
+ * the wait early — reintroducing a softer version of the race we are
+ * trying to remove.
+ *
+ * In bestEffort mode, if the arm window elapses without isPasteInProgress
+ * ever going true, we assume the paste never materialized (zero batches,
+ * immediate error, send loop that did nothing) and resolve without
+ * waiting for the full timeout.
  */
 async function waitForPasteDrain(
   mode: PasteDrainMode,
@@ -928,6 +947,7 @@ async function waitForPasteDrain(
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     let done = false;
+    let seenTrue = false;
     let armHandle: ReturnType<typeof setTimeout> | undefined;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
@@ -962,13 +982,30 @@ async function waitForPasteDrain(
 
     const onAbort = () => rejectErr(new Error("Paste execution aborted"));
 
-    // Subscribe FIRST so we never miss a State:true that arrives between
-    // now and the arm-window check below.
+    // Subscribe FIRST. Every store update runs this callback; we update
+    // the `seenTrue` latch on truthy updates and only take the clean-drain
+    // exit on a falsy update AFTER seenTrue has been latched.
     const unsubscribe = useHidStore.subscribe((state) => {
-      if (!state.isPasteInProgress) {
+      if (state.isPasteInProgress) {
+        seenTrue = true;
+        return;
+      }
+      if (seenTrue) {
         resolveClean();
       }
     });
+
+    // Now sample the current value. If a state change happened between
+    // subscribe() and getState(), the subscription callback above already
+    // set seenTrue — this assignment is harmlessly redundant in that case.
+    // If no change happened, we pick up whatever the store says right now.
+    seenTrue = useHidStore.getState().isPasteInProgress;
+
+    // Fast-reject if the caller already aborted before we even started.
+    if (signal?.aborted) {
+      rejectErr(new Error("Paste execution aborted"));
+      return;
+    }
 
     signal?.addEventListener("abort", onAbort, { once: true });
 
@@ -983,18 +1020,21 @@ async function waitForPasteDrain(
       }
     }, timeoutMs);
 
-    // Arm window — bestEffort only. If isPasteInProgress is still false
-    // after armWindowMs, assume the paste never materialized and resolve.
-    // In required mode the caller is asserting "a paste is in progress or
-    // about to start"; we wait the full timeout budget instead.
-    if (mode === "bestEffort" && !useHidStore.getState().isPasteInProgress) {
+    // Arm window — bestEffort only, and only if we haven't yet seen a
+    // paste become active. If after armWindowMs the store still says
+    // isPasteInProgress === false AND seenTrue is still false, assume
+    // the paste never materialized and resolve. If the store has gone
+    // true during the window, flip seenTrue and defer to the subscription.
+    if (mode === "bestEffort" && !seenTrue) {
       armHandle = setTimeout(() => {
         armHandle = undefined;
-        if (!useHidStore.getState().isPasteInProgress) {
+        if (useHidStore.getState().isPasteInProgress) {
+          seenTrue = true;
+          return;
+        }
+        if (!seenTrue) {
           resolveImmediate();
         }
-        // else: a State:true arrived during the arm window; the subscription
-        // will fire when the matching State:false lands.
       }, armWindowMs);
     }
   });
@@ -1002,6 +1042,8 @@ async function waitForPasteDrain(
 ```
 
 **Placement note:** put this directly above the `export function useKeyboard` declaration (or the equivalent `const useKeyboard = ...` if the file uses that style). It must be OUTSIDE the hook body.
+
+**Why subscribe before getState:** Zustand's `.subscribe()` does not fire with the current value — it fires only on subsequent changes. Subscribing first, then reading `getState()`, closes the small window where a state change could otherwise slip between sampling and wiring the listener. If a mutation lands after subscribe but before getState, the callback runs and sets `seenTrue`; the getState read then picks up the new (still `true`) value and the redundant reassignment leaves `seenTrue` correct. If we reversed the order, a mutation in that window would be missed entirely.
 
 - [ ] **Step 4.4: Replace the inline drain-wait block in `executePasteText`**
 
@@ -1085,7 +1127,7 @@ Run:
 ```bash
 git add ui/src/hooks/useKeyboard.ts
 git commit -m "$(cat <<'EOF'
-feat(paste): waitForPasteDrain helper with subscribe-first arm window (#42)
+feat(paste): waitForPasteDrain helper with subscribe-first seenTrue latch (#42)
 
 Factor the inline drain-wait block inside executePasteText into a reusable
 module-scoped helper waitForPasteDrain(mode, timeoutMs, signal). Mode is
@@ -1096,17 +1138,21 @@ module-scoped helper waitForPasteDrain(mode, timeoutMs, signal). Mode is
 - "required" rejects on timeout. Reserved for #38 (Phase 2) chunk boundaries;
   no call sites in Phase 1.
 
-The helper subscribes to useHidStore BEFORE checking the current
-isPasteInProgress value. This closes the late-start race where the send
-loop finished before the backend's State:true had landed, the store still
-read false, and the naive fast-return reported the paste complete while
-it was still queued and running.
+Correctness: the helper latches a local `seenTrue` flag — "have we ever
+observed isPasteInProgress === true during this wait?" — and only takes
+the clean-drain exit after seenTrue has been set. useHidStore.subscribe()
+without a selector fires on every store mutation, not just
+isPasteInProgress changes, so without the latch an unrelated store update
+during the late-start window would resolve the wait early while the
+backend hasn't yet emitted State:true. The latch combined with a
+subscribe-first-then-sample order closes both the "missed transition"
+and "spurious unrelated update" races.
 
-In bestEffort mode, if isPasteInProgress is still false after a 200ms arm
-window, the helper resolves immediately — handles the "paste never
-materialized" case (zero batches, immediate error) without waiting for the
-full timeout. required mode skips the arm window and waits the full
-timeout budget.
+In bestEffort mode, if the arm window (200ms) elapses without
+isPasteInProgress ever going true, the helper resolves immediately —
+handles the "paste never materialized" case (zero batches, immediate
+error) without waiting for the full timeout. required mode skips the
+arm window and waits the full timeout budget.
 
 executePasteText's inline drain wait is replaced with a single
 `await waitForPasteDrain("bestEffort", drainTimeoutMs, signal)`. The

--- a/docs/superpowers/plans/2026-04-10-paste-depth-semantics.md
+++ b/docs/superpowers/plans/2026-04-10-paste-depth-semantics.md
@@ -1,0 +1,1191 @@
+# Paste-Depth Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Phase 1 paste reliability fixes in one PR: paste-depth semantics with rollback-safe cancellable enqueue (#42), shallow 64-slot macro queue (#48), `UpdateKeysDown` guard on failed HID writes (#34), `onHidMessage` goroutine-leak safety for the new shallow queue, and a frontend `waitForPasteDrain` helper with a subscribe-first arm window that eliminates the late-start race.
+
+**Architecture:** Backend owns its own enqueue cancellation context, rotated by `cancelAndDrainMacroQueue` so blocked enqueuers wake cleanly on user cancel. Every queued item carries its origin `*Session` so state messages return to the session that started the paste, not whichever global `currentSession` happens to be live. State transitions (`State:true` / `State:false`) fire exactly on atomic `pasteDepth` 0↔1 edges, emitted from four sites (enqueue, rollback, drain post-run, cancel sweep). Non-paste macros bypass all paste-depth plumbing entirely.
+
+**Tech Stack:** Go 1.24, TypeScript 5 / React 18, Zustand store, WebRTC data channel for backend↔frontend HID RPC.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-paste-depth-semantics-design.md` — required reading before starting any task.
+
+**Branch:** `fix/paste-depth-semantics` (already cut from `main`; spec already committed).
+
+## Scope and verification constraints
+
+**Touch list (the ONLY files this plan modifies):**
+- `jsonrpc.go`
+- `hidrpc.go`
+- `internal/usbgadget/hid_keyboard.go`
+- `ui/src/hooks/useKeyboard.ts`
+
+**Forbidden files (do NOT touch in any task):**
+- `ui/src/components/popovers/PasteModal.tsx` — user-facing UI unchanged
+- `ui/src/utils/pasteBatches.ts` — Phase 3a scope
+- `ui/src/utils/pasteMacro.ts` — Phase 3a scope (`estimateBatchBytes` is IMPORTED here but not modified)
+- `internal/native/` — unrelated subsystem
+- `internal/hidrpc/message.go` — `KeyboardMacroReport.IsPaste` and `KeyboardMacroState.IsPaste` are already on the wire; no wire format change needed
+- The `PASTE_LOW_WATERMARK` / `PASTE_HIGH_WATERMARK` constants and `bufferedAmount` flow control in `useKeyboard.ts` — #46's concern, preserve exactly
+- `ui/package.json`, `go.mod` — no dependency changes in Phase 1
+
+**Verification model (no unit test framework in this repo):**
+- Frontend: `cd ui && npx tsc --noEmit` and `cd ui && npx eslint './src/**/*.{ts,tsx}'`
+- Backend: `go build ./...` and `go vet ./...`
+- `go test ./...` runs the existing Go test suite; `jsonrpc.go`, `hidrpc.go`, and `internal/usbgadget/` do not currently ship with unit tests, so `go test` is a build-and-vet gate for those packages (it should still pass — no regressions in tests that do exist)
+- Runtime device testing is POST-merge per CLAUDE.md; do not try to run the debug binary from the plan
+
+**Commit convention:** `type(scope): description (#N)` where `type ∈ {fix, feat, refactor, perf, docs, test}` and `scope ∈ {paste, usb, hid, ui}`. Every commit ends with:
+
+```
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+**Never use `--no-verify`, `--amend`, or force-push.** If a hook fails, fix the underlying issue and create a new commit. Commits are one per plan task, not one per sub-step.
+
+## Verified facts (grepped against current `main`)
+
+These were confirmed by reading the files directly and are used throughout the plan:
+
+- `type Session struct` is declared at `webrtc.go:25`. It is exported from package `kvm`. Use `*Session` freely within the package.
+- `reportHidRPCKeyboardMacroState` is a method on `*Session` at `hidrpc.go:255`. Signature: `func (s *Session) reportHidRPCKeyboardMacroState(state hidrpc.KeyboardMacroState)`. No return value.
+- `handleHidRPCMessage` at `hidrpc.go:14` already accepts `session *Session` as its second parameter. `session` is in scope at line 37 where `rpcExecuteKeyboardMacro` is called — no signature change needed for `handleHidRPCMessage`.
+- `onHidMessage` at `hidrpc.go:66` uses an **unbuffered** completion channel (`r := make(chan interface{})`) and a 1-second `time.After` timeout. This is the goroutine leak path.
+- `startMacroQueue` (not `initMacroQueue`) is the existing init helper at `jsonrpc.go:1024`. Reuse this name.
+- `rpcDoExecuteKeyboardMacro(ctx context.Context, macro []hidrpc.KeyboardMacroStep) error` at `jsonrpc.go:1134` is the per-macro executor. `drainMacroQueue` calls it with a per-macro `context.WithCancel`. **Do not touch `rpcDoExecuteKeyboardMacro` itself** — only its caller.
+- Go version is `1.24.4` per `go.mod`. `sync/atomic.Int32` is available (added in 1.19).
+- `keyboardMacroSequence atomic.Uint64` exists at `jsonrpc.go:1128` and is used for macro ID logging. Preserve its use in the rewritten functions.
+- Current drain loop has a `time.Sleep(200 * time.Millisecond)` inter-macro drain delay at `jsonrpc.go:1078`. **This is the fix from PR #41 — preserve it verbatim.**
+- Current `cancelAndDrainMacroQueue` does NOT hold `macroLock` during its drain loop. It takes `macroLock` briefly only to cancel the current macro, then releases it before sweeping the channel. Preserve this pattern.
+
+---
+
+## Task 1: Backend — paste-depth semantics + queue reshape + dispatch update
+
+**Files:**
+- Modify: `jsonrpc.go` (lines 1011–1121 — the entire macro queue section)
+- Modify: `hidrpc.go:37` (the `rpcExecuteKeyboardMacro` call site in `handleHidRPCMessage`)
+
+**Why these are combined into one task:** `rpcExecuteKeyboardMacro`'s signature changes from `(steps)` to `(session, steps, isPaste)`. Its only caller is `hidrpc.go:37`. Splitting would produce an intermediate commit where the package does not build. One task = one commit = one compile-clean state.
+
+**Scope lock for this task:**
+- ✅ Modify `jsonrpc.go` only in the macro queue region (lines ~1011–1126). Do not touch `rpcDoExecuteKeyboardMacro` at line 1134.
+- ✅ Modify `hidrpc.go` only at line 37 (the macro dispatch).
+- ❌ Do NOT touch `hidrpc.go:66` (`onHidMessage`) in this task — that is Task 2.
+- ❌ Do NOT touch any frontend file.
+- ❌ Do NOT remove the 200ms inter-macro sleep at the end of `drainMacroQueue`.
+
+### Steps
+
+- [ ] **Step 1.1: Read the current macro queue section**
+
+Run:
+```
+Read jsonrpc.go lines 1011-1126
+```
+
+Confirm: the variable block at 1011-1020, `startMacroQueue` at 1022-1028, `drainMacroQueue` at 1031-1080, `cancelAndDrainMacroQueue` at 1082-1107, `rpcExecuteKeyboardMacro` at 1109-1121, `rpcCancelKeyboardMacro` at 1123-1125. Note any line drift from these anchors before editing.
+
+- [ ] **Step 1.2: Confirm `atomic` import is already present**
+
+Run:
+```
+Grep in jsonrpc.go imports for "sync/atomic"
+```
+
+Expected: already imported (used by `keyboardMacroSequence atomic.Uint64` at line 1128). If not present, add it in the imports block.
+
+- [ ] **Step 1.3: Replace the var block, add const, struct, and helpers**
+
+Find in `jsonrpc.go` (approximately lines 1011–1028):
+
+```go
+var (
+	// macroQueue is the channel-based FIFO for keyboard macro batches.
+	// The drain goroutine is the sole consumer; rpcExecuteKeyboardMacro is the producer.
+	macroQueue chan []hidrpc.KeyboardMacroStep
+
+	// macroCurrentCancel cancels the currently executing macro in the drain goroutine.
+	macroCurrentCancel context.CancelFunc
+	macroLock          sync.Mutex
+	macroQueueOnce     sync.Once
+)
+
+// startMacroQueue creates the macro queue channel and starts the drain goroutine.
+// Called when the first WebRTC session is established.
+func startMacroQueue() {
+	macroQueueOnce.Do(func() {
+		macroQueue = make(chan []hidrpc.KeyboardMacroStep, 4096)
+		go drainMacroQueue()
+	})
+}
+```
+
+Replace with:
+
+```go
+// macroQueueDepth is the buffered capacity of macroQueue. Keep this shallow so
+// the frontend's bufferedAmount flow control provides real backpressure — a
+// deep queue hides the sender's view of how far behind the backend has fallen.
+// See docs/superpowers/specs/2026-04-08-paste-pipeline-flow-control-design.md.
+const macroQueueDepth = 64
+
+// queuedMacro wraps a macro batch with its paste flag and origin session so
+// drainMacroQueue and cancelAndDrainMacroQueue can report state messages back
+// to the session that enqueued the paste, not whichever global currentSession
+// happens to be live when the edge fires.
+type queuedMacro struct {
+	steps   []hidrpc.KeyboardMacroStep
+	isPaste bool
+	session *Session
+}
+
+var (
+	// macroQueue is the channel-based FIFO for keyboard macro batches.
+	// The drain goroutine is the sole consumer; rpcExecuteKeyboardMacro is the producer.
+	macroQueue chan queuedMacro
+
+	// macroCurrentCancel cancels the currently executing macro in the drain goroutine.
+	macroCurrentCancel context.CancelFunc
+	macroLock          sync.Mutex
+	macroQueueOnce     sync.Once
+
+	// pasteDepth is the atomic count of accepted/executing paste macros.
+	// Incremented by rpcExecuteKeyboardMacro before the blocking channel send,
+	// decremented by drainMacroQueue after each paste macro finishes, by
+	// rpcExecuteKeyboardMacro's rollback branch on cancelled enqueue, and by
+	// cancelAndDrainMacroQueue for each paste macro swept out of the queue.
+	// State:true emits on the 0→1 transition; State:false emits on the 1→0
+	// transition. Non-paste macros never touch this counter.
+	pasteDepth atomic.Int32
+
+	// macroEnqueueCtx is the cancellation context for blocking enqueues.
+	// It is owned by the macro queue (not by any handler or session) and is
+	// rotated by cancelAndDrainMacroQueue so that enqueuers blocked on a full
+	// macroQueue wake up, roll back their paste-depth reservation, and return
+	// ctx.Err() to the caller.
+	macroEnqueueCtx    context.Context
+	macroEnqueueCancel context.CancelFunc
+	macroEnqueueMu     sync.Mutex
+)
+
+// startMacroQueue creates the macro queue channel, the enqueue cancellation
+// context, and starts the drain goroutine. Idempotent — safe to call from
+// every rpcExecuteKeyboardMacro invocation.
+func startMacroQueue() {
+	macroQueueOnce.Do(func() {
+		macroQueue = make(chan queuedMacro, macroQueueDepth)
+		macroEnqueueCtx, macroEnqueueCancel = context.WithCancel(context.Background())
+		go drainMacroQueue()
+	})
+}
+
+// currentEnqueueCtx returns the active enqueue cancellation context under
+// lock. Enqueuers snapshot this once at entry; if cancelAndDrainMacroQueue
+// rotates the context while they're blocked on send, the snapshot they hold
+// still fires on the old Cancel and unblocks them cleanly.
+func currentEnqueueCtx() context.Context {
+	macroEnqueueMu.Lock()
+	defer macroEnqueueMu.Unlock()
+	return macroEnqueueCtx
+}
+
+// emitPasteState reports a paste-session state transition to the origin
+// session. Callers must only invoke this on the 0→1 or 1→0 transition
+// (i.e., when the relevant pasteDepth.Add return value equals 1 or 0
+// respectively). If the session is nil (origin session torn down between
+// enqueue and drain), this silently no-ops — the frontend on the new
+// session will reconcile state through its own fresh subscription.
+func emitPasteState(session *Session, state bool) {
+	if session == nil {
+		return
+	}
+	session.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
+		State:   state,
+		IsPaste: true,
+	})
+}
+```
+
+- [ ] **Step 1.4: Replace `drainMacroQueue` — remove hardcoded emits, add paste-depth decrement**
+
+Find in `jsonrpc.go` (approximately lines 1031–1080):
+
+```go
+// drainMacroQueue is the sole consumer of macroQueue. It executes each macro
+// sequentially and reports completion state to the frontend after each one.
+func drainMacroQueue() {
+	for macro := range macroQueue {
+		macroID := keyboardMacroSequence.Add(1)
+		logger.Info().Uint64("macro_id", macroID).Int("step_count", len(macro)).Msg("executing queued keyboard macro")
+
+		// Report macro start (frontend uses this for isPasteInProgress)
+		if currentSession != nil {
+			currentSession.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
+				State:   true,
+				IsPaste: true,
+			})
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		macroLock.Lock()
+		macroCurrentCancel = cancel
+		macroLock.Unlock()
+
+		err := rpcDoExecuteKeyboardMacro(ctx, macro)
+		if err != nil {
+			logger.Warn().Uint64("macro_id", macroID).Err(err).Msg("queued keyboard macro failed")
+		} else {
+			logger.Info().Uint64("macro_id", macroID).Msg("queued keyboard macro completed")
+		}
+
+		macroLock.Lock()
+		macroCurrentCancel = nil
+		macroLock.Unlock()
+
+		cancel()
+
+		// Report per-macro completion (frontend uses this for draining phase detection)
+		s := hidrpc.KeyboardMacroState{
+			State:   false,
+			IsPaste: true,
+		}
+		if currentSession != nil {
+			currentSession.reportHidRPCKeyboardMacroState(s)
+		}
+
+		// Inter-macro drain delay: gives the host USB stack time to process
+		// buffered HID reports before the next macro arrives. Without this,
+		// back-to-back macros overflow the host's USB input queue, causing
+		// character corruption on busy systems.
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+```
+
+Replace with:
+
+```go
+// drainMacroQueue is the sole consumer of macroQueue. It executes each macro
+// sequentially. Paste-session state transitions (State:true / State:false) are
+// emitted on atomic pasteDepth 0↔1 edges, not per macro — see rpcExecuteKeyboardMacro
+// for the 0→1 emit and the post-run block below for the 1→0 emit.
+func drainMacroQueue() {
+	for item := range macroQueue {
+		macroID := keyboardMacroSequence.Add(1)
+		logger.Info().
+			Uint64("macro_id", macroID).
+			Int("step_count", len(item.steps)).
+			Bool("is_paste", item.isPaste).
+			Msg("executing queued keyboard macro")
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		macroLock.Lock()
+		macroCurrentCancel = cancel
+		macroLock.Unlock()
+
+		err := rpcDoExecuteKeyboardMacro(ctx, item.steps)
+		if err != nil {
+			logger.Warn().Uint64("macro_id", macroID).Err(err).Msg("queued keyboard macro failed")
+		} else {
+			logger.Info().Uint64("macro_id", macroID).Msg("queued keyboard macro completed")
+		}
+
+		macroLock.Lock()
+		macroCurrentCancel = nil
+		macroLock.Unlock()
+
+		cancel()
+
+		// Paste-depth decrement + conditional emit on the 1→0 transition.
+		// Non-paste macros never touch pasteDepth or emit state.
+		if item.isPaste {
+			if pasteDepth.Add(-1) == 0 {
+				emitPasteState(item.session, false)
+			}
+		}
+
+		// Inter-macro drain delay: gives the host USB stack time to process
+		// buffered HID reports before the next macro arrives. Without this,
+		// back-to-back macros overflow the host's USB input queue, causing
+		// character corruption on busy systems.
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+```
+
+Key deletions verified: the `State:true` emit block (old lines 1039–1044) and the `State:false` emit block (old lines 1065–1072) are both removed. Everything else — logging, `macroCurrentCancel` plumbing, ctx cancel, 200ms sleep — is preserved verbatim. The only additions are the new `Bool("is_paste", ...)` log field and the post-run decrement block.
+
+- [ ] **Step 1.5: Replace `cancelAndDrainMacroQueue` — rotate enqueue ctx, sweep with session tracking**
+
+Find in `jsonrpc.go` (approximately lines 1082–1107):
+
+```go
+// cancelAndDrainMacroQueue cancels the currently executing macro and discards
+// all queued macros. Called on session teardown, session takeover, and explicit cancel.
+func cancelAndDrainMacroQueue() {
+	macroLock.Lock()
+	if macroCurrentCancel != nil {
+		macroCurrentCancel()
+		logger.Info().Msg("canceled current keyboard macro")
+	}
+	macroLock.Unlock()
+
+	// Drain any queued macros without executing them
+	if macroQueue != nil {
+		drained := 0
+		for {
+			select {
+			case <-macroQueue:
+				drained++
+			default:
+				if drained > 0 {
+					logger.Info().Int("count", drained).Msg("drained queued keyboard macros")
+				}
+				return
+			}
+		}
+	}
+}
+```
+
+Replace with:
+
+```go
+// cancelAndDrainMacroQueue cancels the currently executing macro, wakes any
+// enqueuers blocked on a full macroQueue, and discards all queued macros.
+// Called on session teardown, session takeover, and explicit cancel.
+//
+// The steps run in order: (1) rotate the enqueue context so blocked enqueuers
+// wake and roll back cleanly, (2) cancel the in-flight macro so drainMacroQueue
+// returns from rpcDoExecuteKeyboardMacro and hits its post-run decrement
+// block, (3) sweep the channel and atomically subtract the discarded paste
+// count from pasteDepth, emitting State:false on a 1→0 transition.
+func cancelAndDrainMacroQueue() {
+	// Step 1: Rotate the enqueue context. Cancel the current one to wake any
+	// enqueuers blocked on macroQueue send; install a fresh context for future
+	// enqueues.
+	macroEnqueueMu.Lock()
+	if macroEnqueueCancel != nil {
+		macroEnqueueCancel()
+	}
+	macroEnqueueCtx, macroEnqueueCancel = context.WithCancel(context.Background())
+	macroEnqueueMu.Unlock()
+
+	// Step 2: Cancel the in-flight macro (if any). drainMacroQueue's post-run
+	// block will decrement pasteDepth and emit State:false if that decrement is
+	// the 1→0 transition.
+	macroLock.Lock()
+	if macroCurrentCancel != nil {
+		macroCurrentCancel()
+		logger.Info().Msg("canceled current keyboard macro")
+	}
+	macroLock.Unlock()
+
+	// Step 3: Sweep any remaining items out of the channel without running them.
+	// Track the session of the last paste item we saw so that if our sweep closes
+	// the paste session (1→0), we emit State:false to the right session.
+	if macroQueue == nil {
+		return
+	}
+	var discardedTotal int
+	var discardedPaste int32
+	var lastPasteSession *Session
+	draining := true
+	for draining {
+		select {
+		case item := <-macroQueue:
+			discardedTotal++
+			if item.isPaste {
+				discardedPaste++
+				lastPasteSession = item.session
+			}
+		default:
+			draining = false
+		}
+	}
+	if discardedTotal > 0 {
+		logger.Info().Int("count", discardedTotal).Msg("drained queued keyboard macros")
+	}
+	if discardedPaste > 0 {
+		if pasteDepth.Add(-discardedPaste) == 0 {
+			emitPasteState(lastPasteSession, false)
+		}
+	}
+}
+```
+
+- [ ] **Step 1.6: Replace `rpcExecuteKeyboardMacro` — new signature, rollback-safe enqueue**
+
+Find in `jsonrpc.go` (approximately lines 1109–1121):
+
+```go
+func rpcExecuteKeyboardMacro(macro []hidrpc.KeyboardMacroStep) error {
+	macroID := keyboardMacroSequence.Add(1)
+	logger.Info().Uint64("macro_id", macroID).Int("step_count", len(macro)).Msg("enqueuing keyboard macro")
+
+	// Ensure queue is started (idempotent)
+	startMacroQueue()
+
+	// Blocking enqueue. If the channel is full (4096 batches), this blocks
+	// until the drain goroutine frees a slot, creating backpressure through
+	// the SCTP stack to the frontend's bufferedAmount flow control.
+	macroQueue <- macro
+	return nil
+}
+```
+
+Replace with:
+
+```go
+func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep, isPaste bool) error {
+	macroID := keyboardMacroSequence.Add(1)
+	logger.Info().
+		Uint64("macro_id", macroID).
+		Int("step_count", len(steps)).
+		Bool("is_paste", isPaste).
+		Msg("enqueuing keyboard macro")
+
+	// Ensure queue is started (idempotent)
+	startMacroQueue()
+
+	// Snapshot the current enqueue cancellation context. If
+	// cancelAndDrainMacroQueue rotates the context while we're blocked on
+	// send, the snapshot we hold still fires on the old Cancel and unblocks
+	// us cleanly.
+	ctx := currentEnqueueCtx()
+
+	// Pre-increment: reserve a paste-depth slot BEFORE we attempt to enqueue.
+	// Emit State:true if this Add is the 0→1 transition.
+	if isPaste {
+		if pasteDepth.Add(1) == 1 {
+			emitPasteState(session, true)
+		}
+	}
+
+	// Cancellable blocking send. If the enqueue context is cancelled (user
+	// pressed cancel → cancelAndDrainMacroQueue rotated the context) before
+	// the channel accepts the item, roll back the pasteDepth increment and
+	// emit State:false if the rollback is itself the 1→0 transition.
+	select {
+	case macroQueue <- queuedMacro{steps: steps, isPaste: isPaste, session: session}:
+		return nil
+	case <-ctx.Done():
+		if isPaste {
+			if pasteDepth.Add(-1) == 0 {
+				emitPasteState(session, false)
+			}
+		}
+		return ctx.Err()
+	}
+}
+```
+
+`rpcCancelKeyboardMacro` (lines 1123–1125) stays exactly as-is — it just calls `cancelAndDrainMacroQueue()`.
+
+- [ ] **Step 1.7: Update the dispatch call site in `hidrpc.go:37`**
+
+Find in `hidrpc.go` (line 37, inside `handleHidRPCMessage`):
+
+```go
+	case hidrpc.TypeKeyboardMacroReport:
+		keyboardMacroReport, err := message.KeyboardMacroReport()
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to get keyboard macro report")
+			return
+		}
+		rpcErr = rpcExecuteKeyboardMacro(keyboardMacroReport.Steps)
+```
+
+Replace the last line of this case block:
+
+```go
+		rpcErr = rpcExecuteKeyboardMacro(session, keyboardMacroReport.Steps, keyboardMacroReport.IsPaste)
+```
+
+`session` is already in scope — it is the second parameter of `handleHidRPCMessage(message hidrpc.Message, session *Session)`. Confirm by re-reading `hidrpc.go:14`.
+
+- [ ] **Step 1.8: Run `go build ./...`**
+
+Run:
+```bash
+go build ./...
+```
+
+Expected: exit 0, no output. If you see an error about `*Session` not being in scope in `jsonrpc.go`, double-check that the `Session` type is declared in the same package (package `kvm` — it is, per `webrtc.go:25`). If you see `undefined: atomic.Int32`, double-check the `sync/atomic` import is present. If you see unused variable errors, check that `macroEnqueueCtx` is referenced by `currentEnqueueCtx`.
+
+- [ ] **Step 1.9: Run `go vet ./...`**
+
+Run:
+```bash
+go vet ./...
+```
+
+Expected: exit 0, no output. Pay particular attention to any `copylocks` warnings (accidental copies of `sync.Mutex`) or `nilctx` warnings (passing a nil context).
+
+- [ ] **Step 1.10: Run `go test ./...` (build-only for untouched packages)**
+
+Run:
+```bash
+go test ./...
+```
+
+Expected: all existing tests pass. `jsonrpc.go`, `hidrpc.go`, and `internal/usbgadget/` do not currently have unit tests that would exercise the new paths, so this is effectively a build-and-vet gate for those packages. If any unrelated test fails, stop and report — do not proceed.
+
+- [ ] **Step 1.11: Commit**
+
+Run:
+```bash
+git add jsonrpc.go hidrpc.go
+git commit -m "$(cat <<'EOF'
+fix(paste): paste-depth semantics + shallow 64-slot queue (#42, #48)
+
+Replace per-macro State:true/State:false emission in drainMacroQueue with
+edge-triggered semantics driven by an atomic pasteDepth counter. State:true
+now fires exactly on the 0->1 transition (from rpcExecuteKeyboardMacro's
+pre-increment); State:false fires exactly on the 1->0 transition (from
+drain post-run, enqueue rollback, or cancel sweep). Non-paste macros
+(button bindings, on-screen keyboard combos) no longer touch pasteDepth
+or produce state-message traffic at all, fixing the live bug where such
+macros were toggling the frontend's isPasteInProgress mid-paste.
+
+rpcExecuteKeyboardMacro now takes (session *Session, steps, isPaste) and
+uses a macro-queue-scoped enqueue cancellation context, rotated by
+cancelAndDrainMacroQueue so that blocked enqueuers wake cleanly on user
+cancel. Every queuedMacro carries its origin session so state emits go
+to the session that started the paste, not whichever global currentSession
+happens to be live when the edge fires.
+
+macroQueue capacity drops from 4096 to a named macroQueueDepth = 64
+constant, per the approved pipeline spec, so the frontend's bufferedAmount
+flow control actually provides backpressure instead of being masked by a
+deep queue.
+
+hidrpc.go:37 dispatch updated to thread session and IsPaste through.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Run `git log --oneline -1` to confirm the commit landed.
+
+**Rollback condition for Task 1:** if `go build` or `go vet` still fails after three corrective attempts, or if `go test ./...` shows a regression in an untouched package, run `git reset --hard HEAD~1` to discard the commit and report the failure with the full build output. Do not proceed to Task 2.
+
+---
+
+## Task 2: Backend — `onHidMessage` goroutine-leak safety + keyboard-macro log downgrade
+
+**Files:**
+- Modify: `hidrpc.go:66-104` (the `onHidMessage` function)
+
+**Why this is separate from Task 1:** the `onHidMessage` fix is logically independent (goroutine leak safety, not paste-depth semantics) and lives in a different function of the same file. Splitting keeps the Task 1 commit focused on the paste-depth change and makes this commit easy to review in isolation or revert on its own.
+
+**Scope lock for this task:**
+- ✅ Modify `hidrpc.go` only inside `onHidMessage` (lines 66–104).
+- ❌ Do NOT touch `handleHidRPCMessage` (lines 14–64).
+- ❌ Do NOT touch `reportHidRPCKeyboardMacroState` (line 255).
+- ❌ Do NOT touch any other file.
+
+### Steps
+
+- [ ] **Step 2.1: Read the current `onHidMessage`**
+
+Run:
+```
+Read hidrpc.go lines 66-104
+```
+
+Confirm the shape: `r := make(chan interface{})` (unbuffered), `go func() { handleHidRPCMessage(...); r <- nil }()`, `select { case <-time.After(1 * time.Second): Warn; case <-r: Debug }`.
+
+- [ ] **Step 2.2: Confirm `hidrpc.TypeKeyboardMacroReport` identifier is reachable**
+
+Run:
+```
+Grep for "TypeKeyboardMacroReport" in hidrpc.go and internal/hidrpc/
+```
+
+Expected: defined in `internal/hidrpc/message.go` as a `Type` constant, already used at `hidrpc.go:31`. The identifier is `hidrpc.TypeKeyboardMacroReport`.
+
+- [ ] **Step 2.3: Apply the buffered-channel and log-downgrade fix**
+
+Find in `hidrpc.go` (lines 93–103):
+
+```go
+	r := make(chan interface{})
+	go func() {
+		handleHidRPCMessage(message, session)
+		r <- nil
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		scopedLogger.Warn().Msg("HID RPC message timed out")
+	case <-r:
+		scopedLogger.Debug().Dur("duration", time.Since(t)).Msg("HID RPC message handled")
+	}
+```
+
+Replace with:
+
+```go
+	// Buffered completion channel so the worker goroutine's send never blocks.
+	// With the shallow 64-slot macroQueue and blocking backpressure on full,
+	// handleHidRPCMessage can legitimately take longer than the 1-second
+	// timeout below. If we left this unbuffered, the worker would block forever
+	// on `r <- nil` once the timeout fired, leaking a goroutine per timed-out
+	// message.
+	r := make(chan interface{}, 1)
+	go func() {
+		handleHidRPCMessage(message, session)
+		r <- nil
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		// Downgrade the timeout log for keyboard-macro messages: with blocking
+		// backpressure from the shallow macroQueue, enqueue taking >1s is an
+		// expected, benign signal that the backend is absorbing flow control,
+		// not a fault.
+		if message.Type() == hidrpc.TypeKeyboardMacroReport {
+			scopedLogger.Debug().Msg("HID RPC keyboard-macro handler took >1s (backpressure)")
+		} else {
+			scopedLogger.Warn().Msg("HID RPC message timed out")
+		}
+	case <-r:
+		scopedLogger.Debug().Dur("duration", time.Since(t)).Msg("HID RPC message handled")
+	}
+```
+
+- [ ] **Step 2.4: Run `go build ./...`**
+
+Run:
+```bash
+go build ./...
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 2.5: Run `go vet ./...`**
+
+Run:
+```bash
+go vet ./...
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 2.6: Run `go test ./...`**
+
+Run:
+```bash
+go test ./...
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 2.7: Commit**
+
+Run:
+```bash
+git add hidrpc.go
+git commit -m "$(cat <<'EOF'
+fix(hid): buffer onHidMessage completion channel and downgrade keyboard-macro timeout log (#48)
+
+The onHidMessage worker previously sent into an unbuffered completion
+channel. If the 1-second handler timeout won the race, the worker would
+block forever on `r <- nil` because nothing was reading — a goroutine
+leak per timed-out message.
+
+This was latent under the 4096-slot queue because enqueue rarely blocked
+longer than 1s. With the new 64-slot queue from the paste-depth change,
+blocking-enqueue-as-backpressure makes >1s handler durations routine on
+a busy host, so the leak would become measurable.
+
+Fix:
+- Buffer the completion channel (capacity 1) so the worker's send is
+  always non-blocking, even after the timeout branch has taken over.
+- Downgrade the timeout log to Debug for TypeKeyboardMacroReport
+  messages specifically — a >1s enqueue under backpressure is expected,
+  not a fault. Other HID RPC message types still log Warn on timeout.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Run `git log --oneline -1` to confirm.
+
+**Rollback condition for Task 2:** if build, vet, or tests fail, run `git reset --hard HEAD~1` and report. Do not proceed to Task 3.
+
+---
+
+## Task 3: Backend — `UpdateKeysDown` early return on failed HID write (#34)
+
+**Files:**
+- Modify: `internal/usbgadget/hid_keyboard.go` (the `KeyboardReport` function at line 365)
+
+**Scope lock for this task:**
+- ✅ Modify only `KeyboardReport` (lines 365–383).
+- ❌ Do NOT touch `UpdateKeysDown` itself (lines ~335–363).
+- ❌ Do NOT touch the write path (`keyboardWriteHidFile`).
+- ❌ Do NOT touch any other function in this file.
+
+### Steps
+
+- [ ] **Step 3.1: Read the current `KeyboardReport` function**
+
+Run:
+```
+Read internal/usbgadget/hid_keyboard.go lines 365-385
+```
+
+Confirm the current shape: `err := u.keyboardWriteHidFile(modifier, keys)`, then `u.RecordWriteResult(err)`, then an `if err != nil` block that only logs, then `u.UpdateKeysDown(modifier, keys)` called unconditionally, then `return err`.
+
+- [ ] **Step 3.2: Apply the early-return fix**
+
+Find in `internal/usbgadget/hid_keyboard.go` (lines 365–383):
+
+```go
+func (u *UsbGadget) KeyboardReport(modifier byte, keys []byte) error {
+	defer u.resetUserInputTime()
+
+	if len(keys) > hidKeyBufferSize {
+		keys = keys[:hidKeyBufferSize]
+	}
+	if len(keys) < hidKeyBufferSize {
+		keys = append(keys, make([]byte, hidKeyBufferSize-len(keys))...)
+	}
+
+	err := u.keyboardWriteHidFile(modifier, keys)
+	u.RecordWriteResult(err)
+	if err != nil {
+		u.log.Warn().Uint8("modifier", modifier).Uints8("keys", keys).Msg("Could not write keyboard report to hidg0")
+	}
+
+	u.UpdateKeysDown(modifier, keys)
+	return err
+}
+```
+
+Replace with:
+
+```go
+func (u *UsbGadget) KeyboardReport(modifier byte, keys []byte) error {
+	defer u.resetUserInputTime()
+
+	if len(keys) > hidKeyBufferSize {
+		keys = keys[:hidKeyBufferSize]
+	}
+	if len(keys) < hidKeyBufferSize {
+		keys = append(keys, make([]byte, hidKeyBufferSize-len(keys))...)
+	}
+
+	err := u.keyboardWriteHidFile(modifier, keys)
+	u.RecordWriteResult(err)
+	if err != nil {
+		u.log.Warn().Uint8("modifier", modifier).Uints8("keys", keys).Msg("Could not write keyboard report to hidg0")
+		// Do NOT update internal key state on a failed write — otherwise
+		// keysDownState diverges from what the host actually received and
+		// subsequent reports will be based on a poisoned snapshot.
+		return err
+	}
+
+	u.UpdateKeysDown(modifier, keys)
+	return nil
+}
+```
+
+Three lines changed: the `if err != nil` block gains a `return err` (and an explanatory comment), and the final `return err` becomes `return nil` since the error path has already returned.
+
+- [ ] **Step 3.3: Run `go build ./...`**
+
+Run:
+```bash
+go build ./...
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 3.4: Run `go vet ./...`**
+
+Run:
+```bash
+go vet ./...
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 3.5: Run `go test ./...`**
+
+Run:
+```bash
+go test ./...
+```
+
+Expected: all existing tests pass. The `internal/usbgadget` package may or may not ship with tests — either way, `go test` exercises the build of the package and the rest of the repo's tests.
+
+- [ ] **Step 3.6: Commit**
+
+Run:
+```bash
+git add internal/usbgadget/hid_keyboard.go
+git commit -m "$(cat <<'EOF'
+fix(usb): do not UpdateKeysDown on failed HID write (#34)
+
+KeyboardReport previously called u.UpdateKeysDown(modifier, keys)
+unconditionally after the HID write, even when keyboardWriteHidFile
+returned an error. That caused u.keysDownState to diverge from what
+the host actually received — a successful write later would then be
+computed from a poisoned snapshot, producing stuck keys or out-of-order
+press/release sequences on the host.
+
+Fix: early-return on write error. If the write fails, log the warning
+and return without touching keysDownState. Internal state now always
+reflects what the host saw.
+
+This is the correctness fix cherry-picked from PR #37 without pulling
+in the rest of that PR's pre-pipeline ACK-per-batch model.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Run `git log --oneline -1` to confirm.
+
+**Rollback condition for Task 3:** if build, vet, or tests fail, run `git reset --hard HEAD~1` and report. Do not proceed to Task 4.
+
+---
+
+## Task 4: Frontend — `waitForPasteDrain` helper + `executePasteText` call-site swap
+
+**Files:**
+- Modify: `ui/src/hooks/useKeyboard.ts` — add a module-scoped `waitForPasteDrain` helper above the `useKeyboard` hook, and replace the inline drain-wait block inside `executePasteText` (lines ~475–508) with a single call to the helper.
+
+**Scope lock for this task:**
+- ✅ Add a new module-scoped function (`waitForPasteDrain`) and a new type alias (`PasteDrainMode`) above the `useKeyboard` hook.
+- ✅ Replace the inline drain-wait block inside `executePasteText`.
+- ❌ Do NOT touch `executeMacroRemote`, `executeMacroClientSide`, or any other callback in this file.
+- ❌ Do NOT touch `PASTE_LOW_WATERMARK`, `PASTE_HIGH_WATERMARK`, the `waitForDrain` local helper (that's bufferedAmount flow control, not paste drain), the `bufferedamountlow` listener, or the `channel.bufferedAmountLowThreshold` assignments.
+- ❌ Do NOT change the `drainTimeoutMs` computation — preserve `Math.max(finalSettleMs, batches.length * 1000)` exactly.
+- ❌ Do NOT touch `ui/src/utils/pasteMacro.ts` or `ui/src/utils/pasteBatches.ts`.
+- ❌ Do NOT touch `useHidStore` definitions in `ui/src/hooks/stores.ts` — `isPasteInProgress` is already declared there.
+
+### Steps
+
+- [ ] **Step 4.1: Read the current `executePasteText` drain-wait block**
+
+Run:
+```
+Read ui/src/hooks/useKeyboard.ts lines 400-520
+```
+
+Confirm: `executePasteText` starts at line 404, the batch send loop is lines 447–473, the inline drain-wait block is lines 475–508, the `finally` block is 509–512.
+
+- [ ] **Step 4.2: Read the top of `useKeyboard.ts` to find the import block and module-scoped declarations**
+
+Run:
+```
+Read ui/src/hooks/useKeyboard.ts lines 1-80
+```
+
+Identify the import block and any existing module-scoped constants (so the new helper can be placed consistently).
+
+- [ ] **Step 4.3: Add the module-scoped `waitForPasteDrain` helper**
+
+Add the following block above the `useKeyboard` hook declaration (directly above the `export function useKeyboard(...)` line, or directly above the nearest module-scoped helper already in the file). This helper must live at module scope, NOT inside `useKeyboard`, because it doesn't use React state.
+
+```typescript
+type PasteDrainMode = "required" | "bestEffort";
+
+const PASTE_DRAIN_DEFAULT_ARM_WINDOW_MS = 200;
+const PASTE_DRAIN_DEFAULT_SETTLE_MS = 500;
+
+/**
+ * Wait for a paste session to drain from the backend macro queue.
+ *
+ * Modes:
+ * - "bestEffort" — resolves on timeout or on the arm window (if no paste ever
+ *   started). Preserves the existing final-settle UX from executePasteText.
+ *   Used by Phase 1's final-drain call site.
+ * - "required" — rejects on timeout, never takes the arm-window fast path.
+ *   Reserved for #38's chunk boundaries in Phase 2. No Phase 1 call sites.
+ *
+ * The helper subscribes to useHidStore BEFORE checking the current
+ * isPasteInProgress value, so a late-arriving backend State:true cannot be
+ * missed. In bestEffort mode, if isPasteInProgress is still false after a
+ * short arm window, we assume the paste never materialized (zero batches,
+ * immediate error, send loop that did nothing) and resolve without waiting
+ * for the full timeout.
+ */
+async function waitForPasteDrain(
+  mode: PasteDrainMode,
+  timeoutMs: number,
+  signal?: AbortSignal,
+  settleMs: number = PASTE_DRAIN_DEFAULT_SETTLE_MS,
+  armWindowMs: number = PASTE_DRAIN_DEFAULT_ARM_WINDOW_MS,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let done = false;
+    let armHandle: ReturnType<typeof setTimeout> | undefined;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (armHandle !== undefined) clearTimeout(armHandle);
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      signal?.removeEventListener("abort", onAbort);
+      unsubscribe();
+    };
+
+    const resolveClean = () => {
+      if (done) return;
+      done = true;
+      cleanup();
+      // Observed drain → host USB settle delay before the caller resumes.
+      setTimeout(resolve, settleMs);
+    };
+
+    const resolveImmediate = () => {
+      if (done) return;
+      done = true;
+      cleanup();
+      resolve();
+    };
+
+    const rejectErr = (err: Error) => {
+      if (done) return;
+      done = true;
+      cleanup();
+      reject(err);
+    };
+
+    const onAbort = () => rejectErr(new Error("Paste execution aborted"));
+
+    // Subscribe FIRST so we never miss a State:true that arrives between
+    // now and the arm-window check below.
+    const unsubscribe = useHidStore.subscribe((state) => {
+      if (!state.isPasteInProgress) {
+        resolveClean();
+      }
+    });
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    timeoutHandle = setTimeout(() => {
+      if (mode === "required") {
+        rejectErr(
+          new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`),
+        );
+      } else {
+        // bestEffort: treat timeout as success, skip settle.
+        resolveImmediate();
+      }
+    }, timeoutMs);
+
+    // Arm window — bestEffort only. If isPasteInProgress is still false
+    // after armWindowMs, assume the paste never materialized and resolve.
+    // In required mode the caller is asserting "a paste is in progress or
+    // about to start"; we wait the full timeout budget instead.
+    if (mode === "bestEffort" && !useHidStore.getState().isPasteInProgress) {
+      armHandle = setTimeout(() => {
+        armHandle = undefined;
+        if (!useHidStore.getState().isPasteInProgress) {
+          resolveImmediate();
+        }
+        // else: a State:true arrived during the arm window; the subscription
+        // will fire when the matching State:false lands.
+      }, armWindowMs);
+    }
+  });
+}
+```
+
+**Placement note:** put this directly above the `export function useKeyboard` declaration (or the equivalent `const useKeyboard = ...` if the file uses that style). It must be OUTSIDE the hook body.
+
+- [ ] **Step 4.4: Replace the inline drain-wait block in `executePasteText`**
+
+Find in `ui/src/hooks/useKeyboard.ts` (approximately lines 475–508):
+
+```typescript
+        // Wait for backend to finish draining all queued macros.
+        // The drain goroutine sends State:false after each macro completes.
+        // We wait for isPasteInProgress to become false (final completion signal),
+        // with a generous timeout based on the number of batches.
+        const drainTimeoutMs = Math.max(finalSettleMs, batches.length * 1000);
+        await new Promise<void>((resolve, reject) => {
+          // If paste is already not in progress (e.g. very small paste), resolve immediately
+          if (!useHidStore.getState().isPasteInProgress) {
+            resolve();
+            return;
+          }
+
+          const timeout = setTimeout(() => {
+            unsubscribe();
+            resolve(); // Resolve on timeout rather than reject — batches were sent successfully
+          }, drainTimeoutMs);
+
+          const abortHandler = () => {
+            clearTimeout(timeout);
+            unsubscribe();
+            reject(new Error("Paste execution aborted"));
+          };
+          signal?.addEventListener("abort", abortHandler, { once: true });
+
+          const unsubscribe = useHidStore.subscribe(state => {
+            if (!state.isPasteInProgress) {
+              clearTimeout(timeout);
+              signal?.removeEventListener("abort", abortHandler);
+              unsubscribe();
+              // Small settle delay after final completion for host USB consumption
+              setTimeout(resolve, 500);
+            }
+          });
+        });
+```
+
+Replace with:
+
+```typescript
+        // Wait for backend to finish draining all queued macros. The helper
+        // subscribes first (no late-start race) and uses an arm window so a
+        // paste that never materialized doesn't block for the full timeout.
+        // bestEffort mode preserves the current final-settle UX — resolves on
+        // timeout, resolves with a settle delay on clean drain, rejects only
+        // on abort.
+        const drainTimeoutMs = Math.max(finalSettleMs, batches.length * 1000);
+        await waitForPasteDrain("bestEffort", drainTimeoutMs, signal);
+```
+
+The `drainTimeoutMs` calculation is preserved verbatim. The `finally` block at line 509 onwards (`channel.removeEventListener("bufferedamountlow", onLow)` and `channel.bufferedAmountLowThreshold = prevThreshold`) is left untouched — `waitForPasteDrain` lives inside the `try` block, so cleanup still runs on both the success and rejection paths.
+
+- [ ] **Step 4.5: Run TypeScript type check**
+
+Run:
+```bash
+cd ui && npx tsc --noEmit
+```
+
+Expected: exit 0, no output. If `waitForPasteDrain` references `useHidStore` and the import is missing, add it to the imports near the top of the file (it is almost certainly already imported — the old inline block used it too). If there are errors about `ReturnType<typeof setTimeout>` being `NodeJS.Timeout` vs. `number`, cast to `number` using `as ReturnType<typeof setTimeout>` — this is a known quirk of DOM types vs. Node types in the React build.
+
+- [ ] **Step 4.6: Run ESLint**
+
+Run:
+```bash
+cd ui && npx eslint './src/**/*.{ts,tsx}'
+```
+
+Expected: exit 0, no output. Pay attention to:
+- `no-unused-vars` — the old inline block may have left a `resolve`/`reject` that's no longer used if you swapped imperfectly
+- `react-hooks/exhaustive-deps` — `waitForPasteDrain` is module-scoped, not a hook dependency, so it should NOT appear in the `executePasteText` `useCallback` dependency array. If ESLint complains about `waitForPasteDrain` being missing from deps, that is a false positive to suppress via a comment — but verify first that the helper really is at module scope.
+
+- [ ] **Step 4.7: Commit**
+
+Run:
+```bash
+git add ui/src/hooks/useKeyboard.ts
+git commit -m "$(cat <<'EOF'
+feat(paste): waitForPasteDrain helper with subscribe-first arm window (#42)
+
+Factor the inline drain-wait block inside executePasteText into a reusable
+module-scoped helper waitForPasteDrain(mode, timeoutMs, signal). Mode is
+"required" | "bestEffort":
+
+- "bestEffort" preserves the existing final-settle UX: resolves on timeout,
+  resolves with a 500ms settle delay on clean drain, rejects only on abort.
+- "required" rejects on timeout. Reserved for #38 (Phase 2) chunk boundaries;
+  no call sites in Phase 1.
+
+The helper subscribes to useHidStore BEFORE checking the current
+isPasteInProgress value. This closes the late-start race where the send
+loop finished before the backend's State:true had landed, the store still
+read false, and the naive fast-return reported the paste complete while
+it was still queued and running.
+
+In bestEffort mode, if isPasteInProgress is still false after a 200ms arm
+window, the helper resolves immediately — handles the "paste never
+materialized" case (zero batches, immediate error) without waiting for the
+full timeout. required mode skips the arm window and waits the full
+timeout budget.
+
+executePasteText's inline drain wait is replaced with a single
+`await waitForPasteDrain("bestEffort", drainTimeoutMs, signal)`. The
+drainTimeoutMs calculation is preserved verbatim; flow control watermarks,
+the bufferedamountlow listener, and the finally-block cleanup are
+untouched.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Run `git log --oneline -1` to confirm.
+
+**Rollback condition for Task 4:** if `tsc --noEmit` or ESLint fails after three corrective attempts, run `git reset --hard HEAD~1` and report. Do not try to paper over TypeScript errors with `any` or `@ts-ignore`.
+
+---
+
+## Post-implementation verification gate (performed by team lead, not by a teammate)
+
+After all four tasks commit, the team lead runs the full verification loop before handing off to code review:
+
+```bash
+cd ui && npx tsc --noEmit
+cd ui && npx eslint './src/**/*.{ts,tsx}'
+cd ..
+go build ./...
+go vet ./...
+go test ./...
+git log --oneline -5
+```
+
+All must pass. The `git log` should show 4 new commits on top of the spec commit(s):
+
+1. `fix(paste): paste-depth semantics + shallow 64-slot queue (#42, #48)` — Task 1
+2. `fix(hid): buffer onHidMessage completion channel and downgrade keyboard-macro timeout log (#48)` — Task 2
+3. `fix(usb): do not UpdateKeysDown on failed HID write (#34)` — Task 3
+4. `feat(paste): waitForPasteDrain helper with subscribe-first arm window (#42)` — Task 4
+
+If verification passes, proceed to Step 7 (code review) of the Phase 1 workflow. If any check fails, fix the issue and amend the relevant task's commit — do NOT create drive-by fix commits that muddy the per-task boundary.
+
+## Runtime validation notes for the PR description
+
+These are NOT run as part of implementation (they require a physical device with USB + HDMI attached). The PR description should list them as post-merge validation:
+
+- 100k-char paste in both `reliable` and `fast` profiles — verify no stalls, no stuck `isPasteInProgress`, no corrupted text on the target
+- Button macro (e.g., `MacroBar.tsx`) fired concurrently with a paste — verify the paste's drain wait does not resolve prematurely when the button macro completes
+- Cancel mid-paste with the queue ≥32 items deep — verify blocked enqueuers wake and return errors, `State:false` fires exactly once, no goroutine leak (capture `curl localhost:9501/debug/pprof/goroutine?debug=2` before/after if the debug endpoint is reachable)
+- `onHidMessage` 1-second timeout fires under heavy backpressure — verify no `Warn`-level logs flood for keyboard-macro messages (should be `Debug`), and no goroutine leak
+- Trailing batches after cancel — confirm the "Known protocol limitation" section of the spec is accurate: a handful of post-cancel keystrokes may still reach the host, and this is expected without wire-level paste IDs
+
+---
+
+## Spec coverage self-check
+
+Every requirement from `docs/superpowers/specs/2026-04-10-paste-depth-semantics-design.md` is implemented by exactly one of the tasks above:
+
+| Spec requirement | Task |
+|---|---|
+| `const macroQueueDepth = 64` | 1 (Step 1.3) |
+| `type queuedMacro struct { steps, isPaste, session }` | 1 (Step 1.3) |
+| `pasteDepth atomic.Int32` | 1 (Step 1.3) |
+| `macroEnqueueCtx/Cancel/Mu` plumbing | 1 (Step 1.3) |
+| `startMacroQueue` inits both queue and enqueue ctx | 1 (Step 1.3) |
+| `currentEnqueueCtx()` helper | 1 (Step 1.3) |
+| `emitPasteState(session, state)` helper | 1 (Step 1.3) |
+| `rpcExecuteKeyboardMacro(session, steps, isPaste)` rollback-safe enqueue | 1 (Step 1.6) |
+| `drainMacroQueue` paste-depth decrement, deletes hardcoded emits | 1 (Step 1.4) |
+| `cancelAndDrainMacroQueue` rotates enqueue ctx, sweeps with session tracking | 1 (Step 1.5) |
+| `hidrpc.go:37` dispatch passes `session` and `IsPaste` | 1 (Step 1.7) |
+| `onHidMessage` buffered completion channel | 2 (Step 2.3) |
+| `onHidMessage` keyboard-macro timeout log downgrade | 2 (Step 2.3) |
+| `KeyboardReport` early return on failed HID write | 3 (Step 3.2) |
+| `waitForPasteDrain` helper with arm window and both modes | 4 (Step 4.3) |
+| `executePasteText` uses `waitForPasteDrain("bestEffort", ...)` | 4 (Step 4.4) |
+| Preserve 200ms inter-macro sleep in `drainMacroQueue` | 1 (Step 1.4) |
+| Preserve `macroCurrentCancel` plumbing in `drainMacroQueue` | 1 (Step 1.4) |
+| Preserve `PASTE_LOW_WATERMARK` / `PASTE_HIGH_WATERMARK` flow control | scope lock on Task 4 |
+| Preserve `drainTimeoutMs = Math.max(finalSettleMs, batches.length * 1000)` | 4 (Step 4.4) |
+| Preserve `finally`-block cleanup in `executePasteText` | scope lock on Task 4 |
+
+No spec section is unimplemented. No task references code not defined in this plan or in the existing repo.

--- a/docs/superpowers/specs/2026-04-10-paste-depth-semantics-design.md
+++ b/docs/superpowers/specs/2026-04-10-paste-depth-semantics-design.md
@@ -1,0 +1,445 @@
+# Paste-Depth Semantics + Shallow Queue + UpdateKeysDown Guard
+
+**Issues:** #42 (completion-waiting race), #48 (macroQueue depth 4096 → 64), #34 (UpdateKeysDown on failed write)
+**Date:** 2026-04-10
+**Approach:** A — Split emit with rollback-safe pre-increment (atomic `pasteDepth`, enqueuer emits `State:true`, drain/rollback/cancel-sweep all emit `State:false` on 1→0 transitions)
+**Branch:** `fix/paste-depth-semantics`
+
+## Problem
+
+Three related correctness bugs share a single root cause — the backend emits macro completion signals at the wrong granularity and drops the `IsPaste` flag at the dispatch boundary.
+
+### What the research verified (current `main`)
+
+- `jsonrpc.go:1014` — `macroQueue chan []hidrpc.KeyboardMacroStep`, capacity `4096`
+- `jsonrpc.go:1033-1080` — `drainMacroQueue()` hardcodes `IsPaste: true` on every `State:true`/`State:false` emission, emitted per-macro rather than per-session
+- `jsonrpc.go:1109-1121` — `rpcExecuteKeyboardMacro(macro []hidrpc.KeyboardMacroStep)` takes no `isPaste` flag
+- `hidrpc.go:37` — `rpcExecuteKeyboardMacro(keyboardMacroReport.Steps)` drops `keyboardMacroReport.IsPaste`
+- `internal/hidrpc/message.go:101-105,192-195` — `KeyboardMacroReport.IsPaste` and `KeyboardMacroState.IsPaste` are **already** on the wire; zero wire-format change needed
+- `internal/usbgadget/hid_keyboard.go:365-382` — `KeyboardReport` unconditionally calls `UpdateKeysDown(modifier, keys)` after `keyboardWriteHidFile`, even when the write errored
+- `ui/src/hooks/useKeyboard.ts:107-108` — frontend already filters `if (!message.isPaste) break` before `setPasteModeEnabled`, but the filter is inert because the backend always sends `true`
+- `ui/src/hooks/useKeyboard.ts:310-329` — `executeMacroRemote(steps, isPaste = false)` already accepts and passes `isPaste` to `sendKeyboardMacroEventHidRpc`
+- `ui/src/hooks/useKeyboard.ts:475-508` — inline drain-wait block in `executePasteText`, resolves on timeout (silently treats "didn't hear back" as success)
+- `MacroBar.tsx:41`, `VirtualKeyboard.tsx:154,161,166` — non-paste `executeMacro` callers that today spuriously toggle `isPasteInProgress` through no fault of their own, because the backend hardcodes `IsPaste: true` on state emit
+
+### The live correctness bug
+
+Any non-paste macro (button bindings, on-screen keyboard Ctrl+Alt+Del, custom user macros) fires `State:true, IsPaste:true` → `State:false, IsPaste:true` pairs through `drainMacroQueue`. The frontend's `setPasteModeEnabled` runs for each, toggling `isPasteInProgress`. If a paste is in flight concurrently, the paste's drain wait sees `isPasteInProgress` flip false and resolves prematurely — the paste is reported complete while macros are still queued and executing.
+
+## Design
+
+### Scope constraints
+
+**Touch list (the only files changed in this PR):**
+- `jsonrpc.go`
+- `hidrpc.go`
+- `internal/hidrpc/message.go` *(no code change expected — struct already has `IsPaste`; listed in case a helper lands here)*
+- `internal/usbgadget/hid_keyboard.go`
+- `ui/src/hooks/useKeyboard.ts`
+
+**Must NOT touch (Phase 1 forbidden list):**
+- `ui/src/components/popovers/PasteModal.tsx` — user-facing UI unchanged
+- `ui/src/utils/pasteBatches.ts` and `ui/src/utils/pasteMacro.ts` — profile retuning is Phase 3a's scope; byte formula is Phase 3a's scope
+- `internal/native/` — unrelated
+- Flow control watermarks (`PASTE_LOW_WATERMARK`, `PASTE_HIGH_WATERMARK`) in `useKeyboard.ts` — #46's concern, preserved exactly
+
+### Backend: `jsonrpc.go`
+
+#### 1. New queue element type and named depth constant
+
+```go
+const macroQueueDepth = 64
+
+type queuedMacro struct {
+    steps   []hidrpc.KeyboardMacroStep
+    isPaste bool
+}
+
+var (
+    macroQueue         chan queuedMacro
+    macroCurrentCancel context.CancelFunc
+    macroLock          sync.Mutex
+    macroQueueOnce     sync.Once
+    pasteDepth         atomic.Int32
+)
+```
+
+The channel carries `queuedMacro` rather than a bare `[]hidrpc.KeyboardMacroStep`, so the drain goroutine knows whether to touch `pasteDepth`.
+
+#### 2. `rpcExecuteKeyboardMacro` — rollback-safe cancellable enqueue
+
+```go
+func rpcExecuteKeyboardMacro(ctx context.Context, steps []hidrpc.KeyboardMacroStep, isPaste bool) error {
+    // Pre-increment: reserve a paste-depth slot BEFORE we attempt to enqueue.
+    // Emit State:true if this is the 0→1 transition.
+    if isPaste {
+        if pasteDepth.Add(1) == 1 {
+            emitPasteState(true)
+        }
+    }
+
+    // Cancellable blocking send. If ctx is cancelled (session teardown or explicit
+    // cancel) before the channel accepts the item, roll back the pasteDepth increment
+    // AND emit State:false if the rollback is itself a 1→0 transition (handles the
+    // case where a later enqueuer's reservation was balanced by our rollback).
+    select {
+    case macroQueue <- queuedMacro{steps: steps, isPaste: isPaste}:
+        return nil
+    case <-ctx.Done():
+        if isPaste {
+            if pasteDepth.Add(-1) == 0 {
+                emitPasteState(false)
+            }
+        }
+        return ctx.Err()
+    }
+}
+```
+
+**Where does `ctx` come from?** The existing call site at `hidrpc.go:37` runs inside `handleHidRPCMessage`, which already has a session context (the WebRTC data-channel handler is invoked per-session). The implementer will thread the same context that `handleHidRPCMessage` receives into `rpcExecuteKeyboardMacro`. If no such ctx is in scope today, fall back to `currentSession.ctx` (or equivalent) so that enqueue unblocks cleanly on session teardown. The implementation task in the plan must confirm the exact ctx source before writing code.
+
+#### 3. `drainMacroQueue` — decrement on completion, emit on 1→0
+
+```go
+func drainMacroQueue() {
+    for item := range macroQueue {
+        // Preserve the full current per-macro execution body verbatim:
+        // per-step timing, macroCurrentCancel ctx plumbing, error reporting,
+        // and logging. The ONLY deletions from current drainMacroQueue are
+        // the two hardcoded State:true/State:false emits (lines 1040-1043
+        // and 1066-1072 in main). The ONLY addition is the post-run
+        // pasteDepth decrement + conditional emit shown below.
+        executeMacroSteps(item.steps)
+
+        if item.isPaste {
+            if pasteDepth.Add(-1) == 0 {
+                emitPasteState(false)
+            }
+        }
+    }
+}
+```
+
+**Key deletions from current `drainMacroQueue`:**
+- The hardcoded `State:true, IsPaste:true` emit at the start of each macro (lines 1040-1043)
+- The hardcoded `State:false, IsPaste:true` emit at the end of each macro (lines 1066-1072)
+
+Non-paste macros no longer produce state-message traffic from `drainMacroQueue` at all. The frontend filter at `useKeyboard.ts:107` already ignores non-paste state messages, so not emitting them is strictly an improvement.
+
+**In-flight cancel semantics:** If `macroCurrentCancel()` is invoked while a paste macro is executing, `executeMacroUnderLock` returns. The post-run block still runs: `pasteDepth.Add(-1)` is executed exactly once for the cancelled in-flight item, matching the "let the drain goroutine decrement the in-flight paste item when it exits" requirement from the amendment.
+
+#### 4. `cancelAndDrainMacroQueue` — sweep queued pastes, decrement once
+
+```go
+func cancelAndDrainMacroQueue() {
+    macroLock.Lock()
+    defer macroLock.Unlock()
+    if macroCurrentCancel != nil {
+        macroCurrentCancel()
+    }
+
+    var discardedPaste int32
+    for {
+        select {
+        case item := <-macroQueue:
+            if item.isPaste {
+                discardedPaste++
+            }
+        default:
+            goto done
+        }
+    }
+done:
+    if discardedPaste > 0 {
+        if pasteDepth.Add(-discardedPaste) == 0 {
+            emitPasteState(false)
+        }
+    }
+}
+```
+
+**Why a single `Add(-discardedPaste)` rather than per-item decrement?** Semantically cleaner (one atomic observation of the transition edge), and avoids emitting `State:false` multiple times if the drain loop crosses 1→0→1→0 rapidly. The batched `Add` observes the final state in one step.
+
+**Race interaction with concurrent enqueues:** `cancelAndDrainMacroQueue` holds `macroLock`, but `rpcExecuteKeyboardMacro` does NOT take `macroLock` — it just does `pasteDepth.Add(1)` and sends on the channel. A concurrent enqueue during cancel is fine: it bumps `pasteDepth`, lands in the now-drained queue, and drains normally after cancel returns. The atomic `pasteDepth` handles the bookkeeping correctly across all interleavings.
+
+#### 5. `emitPasteState` — factored helper
+
+```go
+// emitPasteState centralizes state reporting. Callers must ensure they only call
+// this when they hold the 0→1 or 1→0 transition (i.e., when the relevant
+// pasteDepth.Add return value equals 1 or 0 respectively).
+func emitPasteState(state bool) {
+    if currentSession == nil {
+        return
+    }
+    currentSession.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
+        State:   state,
+        IsPaste: true,
+    })
+}
+```
+
+Called from three sites: `rpcExecuteKeyboardMacro` (enqueue and rollback), `drainMacroQueue` (post-run decrement), `cancelAndDrainMacroQueue` (post-sweep decrement).
+
+### Backend: `hidrpc.go:37` — preserve `IsPaste` through dispatch
+
+```go
+// BEFORE:
+rpcErr = rpcExecuteKeyboardMacro(keyboardMacroReport.Steps)
+
+// AFTER:
+rpcErr = rpcExecuteKeyboardMacro(ctx, keyboardMacroReport.Steps, keyboardMacroReport.IsPaste)
+```
+
+`ctx` is the session/handler context in scope inside `handleHidRPCMessage`. If the current function signature doesn't already accept a context, the implementer threads one in (the WebRTC handler has a session context available).
+
+### Backend: `internal/usbgadget/hid_keyboard.go:365-382` — #34 UpdateKeysDown guard
+
+```go
+func (u *UsbGadget) KeyboardReport(modifier byte, keys []byte) error {
+    defer u.resetUserInputTime()
+    if len(keys) > hidKeyBufferSize {
+        keys = keys[:hidKeyBufferSize]
+    }
+    if len(keys) < hidKeyBufferSize {
+        keys = append(keys, make([]byte, hidKeyBufferSize-len(keys))...)
+    }
+    err := u.keyboardWriteHidFile(modifier, keys)
+    u.RecordWriteResult(err)
+    if err != nil {
+        u.log.Warn().Uint8("modifier", modifier).Uints8("keys", keys).Msg("Could not write keyboard report to hidg0")
+        return err // early return — do NOT UpdateKeysDown on failed write
+    }
+    u.UpdateKeysDown(modifier, keys)
+    return nil
+}
+```
+
+**Why early return** (vs. gated `if err == nil { UpdateKeysDown(...) }`): idiomatic Go, single happy path, no cognitive cost of re-reading the error state. Functionally identical to the gated form.
+
+**Invariant:** after this change, `u.keysDownState` always reflects what the host actually received (modulo unobserved post-write failures further downstream, which are out of scope). A failed write leaves the internal state unchanged rather than poisoning it with keys that never reached the host.
+
+### Frontend: `ui/src/hooks/useKeyboard.ts`
+
+#### 1. New helper: `waitForPasteDrain`
+
+Add a module-scoped async helper (not a React hook — it takes state via getters/subscribers, so it can be a plain function):
+
+```typescript
+type PasteDrainMode = "required" | "bestEffort";
+
+async function waitForPasteDrain(
+  mode: PasteDrainMode,
+  timeoutMs: number,
+  signal?: AbortSignal,
+  settleMs: number = 500,
+): Promise<void> {
+  if (!useHidStore.getState().isPasteInProgress) {
+    return;
+  }
+  return new Promise<void>((resolve, reject) => {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = () => {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      unsubscribe();
+      reject(new Error("Paste execution aborted"));
+    };
+    const unsubscribe = useHidStore.subscribe((state) => {
+      if (!state.isPasteInProgress) {
+        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+        signal?.removeEventListener("abort", onAbort);
+        unsubscribe();
+        setTimeout(resolve, settleMs);
+      }
+    });
+    signal?.addEventListener("abort", onAbort, { once: true });
+    timeoutHandle = setTimeout(() => {
+      unsubscribe();
+      signal?.removeEventListener("abort", onAbort);
+      if (mode === "required") {
+        reject(new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`));
+      } else {
+        resolve();
+      }
+    }, timeoutMs);
+  });
+}
+```
+
+- `"bestEffort"` — resolves on timeout; preserves current final-settle UX
+- `"required"` — rejects on timeout; used by #38's chunk boundaries in Phase 2 (call sites added there, not here)
+- Both modes preserve the existing 500ms settle delay after a clean drain signal (the current `setTimeout(resolve, 500)` in `executePasteText`)
+
+#### 2. Replace the inline drain wait in `executePasteText`
+
+**Current (lines ~475-508):** ~33 lines of inline promise construction with timeout/abort/subscribe bookkeeping.
+
+**Replacement:**
+```typescript
+const drainTimeoutMs = Math.max(finalSettleMs, batches.length * 1000);
+try {
+  await waitForPasteDrain("bestEffort", drainTimeoutMs, signal);
+} catch (err) {
+  // bestEffort only rejects on abort, not on timeout
+  throw err;
+}
+```
+
+No behavioral change in Phase 1 — `"bestEffort"` resolves on timeout exactly like the current code does.
+
+#### 3. Nothing else changes
+
+- `isPasteInProgress` store slice: unchanged (already exists in `useHidStore`)
+- Message handler at `useKeyboard.ts:106-108`: unchanged (already filters on `message.isPaste`; the filter becomes effective once the backend stops hardcoding `true`)
+- `executeMacroRemote`: unchanged (already passes `isPaste`)
+- Flow control watermarks, abort wiring, batch send loop: unchanged
+- `buildPasteMacroBatches`, `estimateBatchBytes`, `pasteMacro.ts`: untouched (Phase 3a scope)
+
+## Correctness invariants
+
+### Invariant 1: depth-count honesty
+
+At any instant,
+
+```
+pasteDepth == (count of paste items currently in macroQueue)
+              + (1 if a paste item is currently executing in drain, else 0)
+              + (count of paste items whose enqueuer has pre-incremented but not yet
+                 successfully sent or rolled back)
+```
+
+The third term is transient and bounded: each enqueuer holds one provisional slot until the `select` resolves one way or the other. There is no path where a provisional slot leaks — every `Add(1)` is paired with either a successful send (handing ownership to the channel/drain) or an `Add(-1)` on the `ctx.Done()` branch.
+
+### Invariant 2: balanced state transitions
+
+`emitPasteState(true)` fires exactly when some `pasteDepth.Add(1)` returns 1.
+`emitPasteState(false)` fires exactly when some `pasteDepth.Add(±n)` returns 0.
+
+Because atomic operations are totally ordered, every 0→1 transition is followed by exactly one 1→0 transition before the next 0→1, and vice versa. Therefore, across the lifetime of the process, `emitPasteState(true)` and `emitPasteState(false)` are called in alternating order starting with `true`. The frontend sees a balanced sequence of state-open / state-close pairs.
+
+### Invariant 3: no spurious state for non-paste macros
+
+`drainMacroQueue` only calls `emitPasteState` for items with `item.isPaste == true`. Non-paste items (button bindings, on-screen keyboard combos, custom macros) traverse the queue, execute under the same `executeMacroUnderLock`, and produce zero state-message traffic. This fixes the live bug where `MacroBar.tsx`-triggered macros were toggling `isPasteInProgress`.
+
+### Race scenario walkthrough
+
+**Scenario A — clean single paste:**
+1. Frontend sends paste macro M1 with `isPaste=true`
+2. Enqueuer: `pasteDepth.Add(1)` → 1, emit `State:true`
+3. Enqueuer: channel send succeeds, returns nil
+4. Drain: dequeues M1, runs it
+5. Drain: `pasteDepth.Add(-1)` → 0, emit `State:false`
+
+Frontend sees: `State:true` → `State:false`. Balanced.
+
+**Scenario B — overlapping pastes:**
+1. Enqueuer A (paste M1): `Add(1)` → 1, emit `State:true`, send OK
+2. Enqueuer B (paste M2): `Add(1)` → 2, no emit, send OK
+3. Drain: runs M1, `Add(-1)` → 1, no emit
+4. Drain: runs M2, `Add(-1)` → 0, emit `State:false`
+
+Frontend sees: `State:true` → `State:false`. Balanced across both macros.
+
+**Scenario C — non-paste macro runs concurrently with paste:**
+1. Enqueuer A (paste M1): `Add(1)` → 1, emit `State:true`, send OK
+2. Enqueuer B (button macro M2, `isPaste=false`): no `pasteDepth` touch, send OK
+3. Drain: runs M1, `Add(-1)` → 1 (wait — this doesn't match; pasteDepth was 1, so `Add(-1)` → 0 here)
+
+Let me retrace: step 1 leaves `pasteDepth = 1`. Step 2 doesn't touch it. Step 3 drain runs M1, `Add(-1)` → 0, emit `State:false`. Step 4 drain runs M2, no `pasteDepth` touch, no emit.
+
+Frontend sees: `State:true` → `State:false`. The button macro produces no state traffic. Balanced, and the paste's drain wait isn't disturbed by the button macro.
+
+**Scenario D — enqueue rollback on cancelled context:**
+1. `pasteDepth = 0`
+2. Enqueuer A: `Add(1)` → 1, emit `State:true`
+3. Enqueuer A: channel is full, blocks on send
+4. Session context cancelled
+5. Enqueuer A: `select` takes `ctx.Done()` branch, `Add(-1)` → 0, emit `State:false`
+6. Enqueuer A returns `ctx.Err()`
+
+Frontend sees: `State:true` → `State:false`. Balanced. No depth leak. If the session is gone, the frontend won't receive either message, which is fine — the frontend's drain-wait rejects via the abort signal path anyway.
+
+**Scenario E — enqueue rollback while others are still running:**
+1. `pasteDepth = 0`
+2. A: `Add(1)` → 1, emit `State:true`, blocks on send (queue full)
+3. B: `Add(1)` → 2, also blocks
+4. Drain eats a non-paste item, making room
+5. B: send succeeds, returns nil (no emit — new value was 2)
+6. A: ctx cancels, `Add(-1)` → 1, no emit (not 1→0)
+7. B arrives at drain, runs, `Add(-1)` → 0, emit `State:false`
+
+Frontend sees: `State:true` (from A) → `State:false` (from B's drain decrement). Balanced. No leak: A's rollback didn't emit, B's drain did.
+
+**Scenario F — mid-paste user cancel:**
+1. Pre-state: `pasteDepth = 5` (one running in drain, four queued)
+2. User presses cancel, `cancelAndDrainMacroQueue` invoked
+3. `macroCurrentCancel()` aborts the in-flight macro; it returns from `executeMacroUnderLock`
+4. Sweep loop dequeues the four queued paste items (they run no code) and sets `discardedPaste = 4`
+5. Drain goroutine's post-run block: `pasteDepth.Add(-1)` for the in-flight item
+6. Cancel sweep's post-loop block: `pasteDepth.Add(-4)` for the discarded items
+
+Steps 5 and 6 race. Both are atomic `Add`s with return-value edge detection. Exactly one of the two interleavings below occurs:
+
+- **Sweep before drain:** `Add(-4)` returns 1 (no emit) → `Add(-1)` returns 0 (emit `State:false`) ✓
+- **Drain before sweep:** `Add(-1)` returns 4 (no emit) → `Add(-4)` returns 0 (emit `State:false`) ✓
+
+Whichever op observes the final 0 is the one that emits. No double-emit, no miss, no negative depth. Frontend sees exactly one `State:false` for the cancelled session.
+
+**What about adversarial ordering with a new enqueue mid-cancel?**
+- pre-state: `pasteDepth = 5`, 1 running + 4 queued
+- Sweep: `Add(-4)` → 1
+- New enqueue X: `Add(1)` → 2, emits nothing (not 0→1), starts blocking send
+- Drain: `Add(-1)` → 1, does not emit
+- Sweep: returns (queue was empty when it swept)
+- X: send succeeds. X is now in the queue alone with `pasteDepth = 1`.
+- Drain wakes up, runs X, `Add(-1)` → 0, emits `State:false`
+
+Frontend sees: `State:true` (from A's original enqueue way before) → `State:false` (from X's drain). Balanced. No gap even across a user cancel.
+
+But wait — X emitted no `State:true`. Is that a problem? The session was already "open" from A's earlier emit, and the frontend views this as one continuous session. Once the session closes (via X's drain decrement), it's closed. No inconsistency for the frontend.
+
+**What if the entire paste completes during sweep and a new paste starts?**
+- pre-state: `pasteDepth = 1`, the in-flight M is the last one, about to finish
+- Sweep: queue empty, `discardedPaste = 0`, sweep does nothing
+- Drain: `Add(-1)` → 0, emits `State:false`
+- New enqueue Y: `Add(1)` → 1, emits `State:true`, sends OK
+
+Frontend sees: `...` → `State:false` → `State:true` → (eventually) `State:false`. Two sessions, each balanced. ✓
+
+### Invariant 4: no negative depth
+
+Given that (a) all decrement sites check `Add(-n) == 0` rather than `<= 0`, (b) the sweep's `Add(-discardedPaste)` subtracts only items it actually dequeued, (c) `discardedPaste` is bounded by the number of paste items the sweep pulled out of the channel, and (d) the drain loop only decrements items it actually dequeued — the sum of all decrements across all paths exactly equals the sum of all successful increments. Therefore `pasteDepth` can never go negative, and the emit condition `Add returned 0` fires exactly once per completed session.
+
+## Testing and verification
+
+### Compile-time / static
+
+- `cd ui && npx tsc --noEmit`
+- `cd ui && npx eslint './src/**/*.{ts,tsx}'`
+- `go build ./...`
+- `go vet ./...`
+- `go test ./...` for any package touched (usbgadget and jsonrpc if reachable by a test; the repo does not have a unit test harness for jsonrpc today so this may be a no-op)
+
+### Runtime
+
+Device testing is deferred until after PR review. The verification loop in Step 6 of the workflow runs only the static checks. A plan-level "smoke test" note in the PR body advises the reviewer that runtime validation (100k-char paste, button-macro concurrent with paste, cancel mid-paste) is a post-merge activity.
+
+## Out of scope (explicit non-goals)
+
+- Per-session paste IDs / `pasteSessionId` field on messages — #42 body defers these; not needed for depth semantics
+- Chunk boundaries for large pastes (#38, Phase 2) — relies on `waitForPasteDrain("required", ...)` call sites, added in Phase 2
+- Profile retuning (#40, Phase 3a) — `pasteBatches.ts` / `pasteMacro.ts` untouched
+- Timer reuse in the drain loop (#43, Phase 3b) — `jsonrpc.go` timer allocations not part of this PR
+- Timed-sequence HID writer (#44, Phase 4) — `hid_keyboard.go` write path not restructured; only the #34 guard lands
+- Frontend vitest harness (#45, Phase 5) — no test infrastructure added
+- Any backend changes outside the three functions listed in the touch list
+
+## Open question for the implementation task
+
+**Where does `ctx` come from at `hidrpc.go:37`?** The research report did not capture the surrounding 30 lines of `handleHidRPCMessage`. The Step 5 implementation task must verify that:
+
+1. `handleHidRPCMessage` (or its caller) receives a context.Context bound to the session lifetime
+2. That context is passed through to `rpcExecuteKeyboardMacro`
+3. No existing code path relies on `rpcExecuteKeyboardMacro` being callable without a context (it should not — this is the only caller per the research)
+
+If the current handler does not accept a context today, the implementer adds one. The plan-writing step (Step 4) will include a small subtask for this discovery.

--- a/docs/superpowers/specs/2026-04-10-paste-depth-semantics-design.md
+++ b/docs/superpowers/specs/2026-04-10-paste-depth-semantics-design.md
@@ -2,7 +2,7 @@
 
 **Issues:** #42 (completion-waiting race), #48 (macroQueue depth 4096 → 64), #34 (UpdateKeysDown on failed write)
 **Date:** 2026-04-10
-**Approach:** A — Split emit with rollback-safe pre-increment (atomic `pasteDepth`, enqueuer emits `State:true`, drain/rollback/cancel-sweep all emit `State:false` on 1→0 transitions)
+**Approach:** A — Split emit with rollback-safe pre-increment (atomic `pasteDepth`, enqueuer emits `State:true`, drain/rollback/cancel-sweep all emit `State:false` on 1→0 transitions). Enqueue cancellation is anchored on a macro-queue-scoped context that `cancelAndDrainMacroQueue` rotates, and every queued item carries its origin `*Session` so state messages always return to the session that started the paste.
 **Branch:** `fix/paste-depth-semantics`
 
 ## Problem
@@ -31,11 +31,12 @@ Any non-paste macro (button bindings, on-screen keyboard Ctrl+Alt+Del, custom us
 ### Scope constraints
 
 **Touch list (the only files changed in this PR):**
-- `jsonrpc.go`
-- `hidrpc.go`
-- `internal/hidrpc/message.go` *(no code change expected — struct already has `IsPaste`; listed in case a helper lands here)*
-- `internal/usbgadget/hid_keyboard.go`
-- `ui/src/hooks/useKeyboard.ts`
+- `jsonrpc.go` — `macroQueue` type + depth, `pasteDepth`, `rpcExecuteKeyboardMacro`, `drainMacroQueue`, `cancelAndDrainMacroQueue`, `emitPasteState`, enqueue-ctx plumbing
+- `hidrpc.go` — `hidrpc.go:37` dispatch change (pass `session` and `IsPaste`); `onHidMessage` buffered-done-channel safety fix + keyboard-macro timeout log downgrade
+- `internal/usbgadget/hid_keyboard.go` — `#34` early return on failed `keyboardWriteHidFile`
+- `ui/src/hooks/useKeyboard.ts` — `waitForPasteDrain` helper; replace inline drain-wait block in `executePasteText`
+
+`internal/hidrpc/message.go` is **read, not written** — the research confirmed `KeyboardMacroReport.IsPaste` and `KeyboardMacroState.IsPaste` are already present on both types and already marshalled over the wire. Zero change needed there.
 
 **Must NOT touch (Phase 1 forbidden list):**
 - `ui/src/components/popovers/PasteModal.tsx` — user-facing UI unchanged
@@ -45,7 +46,7 @@ Any non-paste macro (button bindings, on-screen keyboard Ctrl+Alt+Del, custom us
 
 ### Backend: `jsonrpc.go`
 
-#### 1. New queue element type and named depth constant
+#### 1. New queue element type, named depth constant, and enqueue-cancel plumbing
 
 ```go
 const macroQueueDepth = 64
@@ -53,42 +54,77 @@ const macroQueueDepth = 64
 type queuedMacro struct {
     steps   []hidrpc.KeyboardMacroStep
     isPaste bool
+    session *Session // origin session — receives State:true/State:false emits
 }
 
 var (
     macroQueue         chan queuedMacro
-    macroCurrentCancel context.CancelFunc
+    macroCurrentCancel context.CancelFunc // cancels the in-flight macro
     macroLock          sync.Mutex
     macroQueueOnce     sync.Once
     pasteDepth         atomic.Int32
+
+    // Enqueue-side cancellation. Owned by the macro queue (not a session or
+    // handler), and rotated by cancelAndDrainMacroQueue so that any enqueuer
+    // blocked on a full macroQueue wakes up, rolls back its paste-depth
+    // reservation, and returns ctx.Err() to the caller.
+    macroEnqueueCtx    context.Context
+    macroEnqueueCancel context.CancelFunc
+    macroEnqueueMu     sync.Mutex
 )
+
+func initMacroQueue() {
+    macroQueueOnce.Do(func() {
+        macroQueue = make(chan queuedMacro, macroQueueDepth)
+        macroEnqueueCtx, macroEnqueueCancel = context.WithCancel(context.Background())
+        go drainMacroQueue()
+    })
+}
+
+// currentEnqueueCtx returns the active enqueue-cancellation context under lock.
+// Snapshot it once at the start of rpcExecuteKeyboardMacro so that a rotation
+// during enqueue still unblocks the caller that was reading the old context.
+func currentEnqueueCtx() context.Context {
+    macroEnqueueMu.Lock()
+    defer macroEnqueueMu.Unlock()
+    return macroEnqueueCtx
+}
 ```
 
-The channel carries `queuedMacro` rather than a bare `[]hidrpc.KeyboardMacroStep`, so the drain goroutine knows whether to touch `pasteDepth`.
+The channel carries `queuedMacro` rather than a bare `[]hidrpc.KeyboardMacroStep`, so the drain goroutine knows whether to touch `pasteDepth` and which session to report state to.
+
+**Why a queue-scoped enqueue context rather than a handler/session context?** The current `handleHidRPCMessage` does not carry a context, and `onHidMessage`'s 1-second timeout goroutine does not give the enqueuer a cancel-aware deadline. Explicit user cancel arrives as a separate HID RPC message (not via context cancellation of the enqueue caller), so a per-call or per-session context would NOT wake blocked enqueuers when the user clicks cancel. The queue owns its own cancellation, and `cancelAndDrainMacroQueue` rotates it in one atomic operation — this is the only primitive that actually wakes every currently-blocked enqueuer.
 
 #### 2. `rpcExecuteKeyboardMacro` — rollback-safe cancellable enqueue
 
 ```go
-func rpcExecuteKeyboardMacro(ctx context.Context, steps []hidrpc.KeyboardMacroStep, isPaste bool) error {
+func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep, isPaste bool) error {
+    initMacroQueue()
+
+    // Snapshot the current enqueue cancellation context. If cancelAndDrainMacroQueue
+    // rotates the context while we're blocked on send, the snapshot we hold still
+    // fires on the old Cancel and unblocks us cleanly.
+    ctx := currentEnqueueCtx()
+
     // Pre-increment: reserve a paste-depth slot BEFORE we attempt to enqueue.
-    // Emit State:true if this is the 0→1 transition.
+    // Emit State:true if this Add is the 0→1 transition.
     if isPaste {
         if pasteDepth.Add(1) == 1 {
-            emitPasteState(true)
+            emitPasteState(session, true)
         }
     }
 
-    // Cancellable blocking send. If ctx is cancelled (session teardown or explicit
-    // cancel) before the channel accepts the item, roll back the pasteDepth increment
-    // AND emit State:false if the rollback is itself a 1→0 transition (handles the
-    // case where a later enqueuer's reservation was balanced by our rollback).
+    // Cancellable blocking send. If the enqueue context is cancelled (user
+    // pressed cancel → cancelAndDrainMacroQueue rotated the context) before
+    // the channel accepts the item, roll back the pasteDepth increment and
+    // emit State:false if the rollback is itself the 1→0 transition.
     select {
-    case macroQueue <- queuedMacro{steps: steps, isPaste: isPaste}:
+    case macroQueue <- queuedMacro{steps: steps, isPaste: isPaste, session: session}:
         return nil
     case <-ctx.Done():
         if isPaste {
             if pasteDepth.Add(-1) == 0 {
-                emitPasteState(false)
+                emitPasteState(session, false)
             }
         }
         return ctx.Err()
@@ -96,9 +132,9 @@ func rpcExecuteKeyboardMacro(ctx context.Context, steps []hidrpc.KeyboardMacroSt
 }
 ```
 
-**Where does `ctx` come from?** The existing call site at `hidrpc.go:37` runs inside `handleHidRPCMessage`, which already has a session context (the WebRTC data-channel handler is invoked per-session). The implementer will thread the same context that `handleHidRPCMessage` receives into `rpcExecuteKeyboardMacro`. If no such ctx is in scope today, fall back to `currentSession.ctx` (or equivalent) so that enqueue unblocks cleanly on session teardown. The implementation task in the plan must confirm the exact ctx source before writing code.
+The signature is `(session *Session, steps, isPaste)` — no ambient context parameter. The queue owns its own cancellation and the caller only has to supply the origin session for state reporting.
 
-#### 3. `drainMacroQueue` — decrement on completion, emit on 1→0
+#### 3. `drainMacroQueue` — decrement on completion, emit to origin session on 1→0
 
 ```go
 func drainMacroQueue() {
@@ -113,12 +149,14 @@ func drainMacroQueue() {
 
         if item.isPaste {
             if pasteDepth.Add(-1) == 0 {
-                emitPasteState(false)
+                emitPasteState(item.session, false)
             }
         }
     }
 }
 ```
+
+State is emitted to `item.session` — the session that originally enqueued the paste — rather than whichever global `currentSession` happens to be live at drain time. This matters when a user switches sessions (reloads the UI, reconnects) between enqueue and drain: the old session may be gone, in which case `emitPasteState` no-ops, and the frontend on the new session will reconcile state through its own fresh subscription rather than seeing cross-talk from the prior session's paste.
 
 **Key deletions from current `drainMacroQueue`:**
 - The hardcoded `State:true, IsPaste:true` emit at the start of each macro (lines 1040-1043)
@@ -128,31 +166,54 @@ Non-paste macros no longer produce state-message traffic from `drainMacroQueue` 
 
 **In-flight cancel semantics:** If `macroCurrentCancel()` is invoked while a paste macro is executing, `executeMacroUnderLock` returns. The post-run block still runs: `pasteDepth.Add(-1)` is executed exactly once for the cancelled in-flight item, matching the "let the drain goroutine decrement the in-flight paste item when it exits" requirement from the amendment.
 
-#### 4. `cancelAndDrainMacroQueue` — sweep queued pastes, decrement once
+#### 4. `cancelAndDrainMacroQueue` — rotate enqueue ctx, sweep queued pastes, decrement once
 
 ```go
 func cancelAndDrainMacroQueue() {
     macroLock.Lock()
     defer macroLock.Unlock()
+
+    // Step 1: Rotate the enqueue context. Cancel the current one to wake any
+    // enqueuers blocked on macroQueue send; install a fresh context for future
+    // enqueues. This is the ONLY primitive that actually unblocks pending
+    // enqueuers — waking them up lets them roll back their paste-depth
+    // reservation cleanly and return ctx.Err() to their callers, so the
+    // frontend's paste attempt fails fast instead of hanging.
+    macroEnqueueMu.Lock()
+    if macroEnqueueCancel != nil {
+        macroEnqueueCancel()
+    }
+    macroEnqueueCtx, macroEnqueueCancel = context.WithCancel(context.Background())
+    macroEnqueueMu.Unlock()
+
+    // Step 2: Cancel the in-flight macro (if any). drainMacroQueue's post-run
+    // block will decrement pasteDepth and emit State:false if that decrement
+    // is the 1→0 transition.
     if macroCurrentCancel != nil {
         macroCurrentCancel()
     }
 
+    // Step 3: Sweep any remaining items out of the channel without running
+    // them. Track the last paste session we saw so that if our sweep closes
+    // the paste session (1→0), we emit State:false to the right session.
     var discardedPaste int32
-    for {
+    var lastPasteSession *Session
+    draining := true
+    for draining {
         select {
         case item := <-macroQueue:
             if item.isPaste {
                 discardedPaste++
+                lastPasteSession = item.session
             }
         default:
-            goto done
+            draining = false
         }
     }
-done:
+
     if discardedPaste > 0 {
         if pasteDepth.Add(-discardedPaste) == 0 {
-            emitPasteState(false)
+            emitPasteState(lastPasteSession, false)
         }
     }
 }
@@ -160,38 +221,102 @@ done:
 
 **Why a single `Add(-discardedPaste)` rather than per-item decrement?** Semantically cleaner (one atomic observation of the transition edge), and avoids emitting `State:false` multiple times if the drain loop crosses 1→0→1→0 rapidly. The batched `Add` observes the final state in one step.
 
-**Race interaction with concurrent enqueues:** `cancelAndDrainMacroQueue` holds `macroLock`, but `rpcExecuteKeyboardMacro` does NOT take `macroLock` — it just does `pasteDepth.Add(1)` and sends on the channel. A concurrent enqueue during cancel is fine: it bumps `pasteDepth`, lands in the now-drained queue, and drains normally after cancel returns. The atomic `pasteDepth` handles the bookkeeping correctly across all interleavings.
+**Which session does the sweep emit to?** All paste items from a single `executePasteText` call are enqueued by the same WebRTC session's handler, so they all carry the same `*Session`. Using the last-seen one during the sweep is sufficient: if the sweep discards any paste items at all, they belong to the same session, and that session receives the `State:false`. If the sweep discards zero paste items, no emit is needed (either there was no paste or the drain goroutine's own decrement handles the transition).
 
-#### 5. `emitPasteState` — factored helper
+**Race interaction with concurrent enqueues:** `cancelAndDrainMacroQueue` holds `macroLock`, but `rpcExecuteKeyboardMacro` does NOT take `macroLock` — it snapshots the enqueue context, does `pasteDepth.Add(1)`, and attempts to send on the channel. A concurrent enqueue during cancel resolves one of two ways:
+- If the enqueuer already captured the **old** enqueue context, the rotation fires `Done()` on it and the enqueuer rolls back via the `ctx.Done()` branch of `select`.
+- If the enqueuer captures the **new** enqueue context (after the rotation), it enqueues into the now-drained queue normally and its item runs on the next drain pass.
+
+Either way, the atomic `pasteDepth` stays honest and no leaks occur.
+
+#### 5. `emitPasteState` — factored helper, session-scoped
 
 ```go
 // emitPasteState centralizes state reporting. Callers must ensure they only call
-// this when they hold the 0→1 or 1→0 transition (i.e., when the relevant
-// pasteDepth.Add return value equals 1 or 0 respectively).
-func emitPasteState(state bool) {
-    if currentSession == nil {
+// this on the 0→1 or 1→0 transition (i.e., when the relevant pasteDepth.Add
+// return value equals 1 or 0 respectively). The session parameter is the
+// origin session — the one that enqueued the paste — so state messages are
+// always delivered to the session that is waiting for them.
+func emitPasteState(session *Session, state bool) {
+    if session == nil {
         return
     }
-    currentSession.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
+    session.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
         State:   state,
         IsPaste: true,
     })
 }
 ```
 
-Called from three sites: `rpcExecuteKeyboardMacro` (enqueue and rollback), `drainMacroQueue` (post-run decrement), `cancelAndDrainMacroQueue` (post-sweep decrement).
+Called from four sites, each passing the correct session:
+- `rpcExecuteKeyboardMacro` enqueue path: `emitPasteState(session, true)` — the caller's session
+- `rpcExecuteKeyboardMacro` rollback path: `emitPasteState(session, false)` — the caller's session
+- `drainMacroQueue` post-run: `emitPasteState(item.session, false)` — the session snapshotted at enqueue
+- `cancelAndDrainMacroQueue` sweep: `emitPasteState(lastPasteSession, false)` — the session of the last paste item swept
 
-### Backend: `hidrpc.go:37` — preserve `IsPaste` through dispatch
+If the origin session has been torn down (user reconnected, browser closed), `emitPasteState` silently no-ops. The frontend on the new session reconciles its state through its own fresh subscription.
+
+### Backend: `hidrpc.go:37` — preserve `IsPaste` and pass origin session
 
 ```go
 // BEFORE:
 rpcErr = rpcExecuteKeyboardMacro(keyboardMacroReport.Steps)
 
 // AFTER:
-rpcErr = rpcExecuteKeyboardMacro(ctx, keyboardMacroReport.Steps, keyboardMacroReport.IsPaste)
+rpcErr = rpcExecuteKeyboardMacro(session, keyboardMacroReport.Steps, keyboardMacroReport.IsPaste)
 ```
 
-`ctx` is the session/handler context in scope inside `handleHidRPCMessage`. If the current function signature doesn't already accept a context, the implementer threads one in (the WebRTC handler has a session context available).
+`session` is the `*Session` receiver / parameter of the enclosing handler. The implementation task must verify how `session` is reachable from the current `handleHidRPCMessage` (it is the WebRTC data-channel handler's owning session — the implementer reads the function signature and adjusts). No ambient `context.Context` is threaded through; enqueue cancellation is owned by the macro queue itself, not by this handler.
+
+### Backend: `hidrpc.go` `onHidMessage` — unblock the 1-second timeout worker
+
+The approved pipeline spec assumed `onHidMessage` stayed under its 1-second handler timeout because enqueue returned promptly. Shrinking `macroQueue` from 4096 to 64 combined with blocking-enqueue-as-backpressure invalidates that assumption: a busy host can easily keep the queue full for longer than 1 second, and the handler's timeout can race the worker.
+
+**Current shape (as understood from the research) and the bug:**
+
+```go
+// Roughly:
+done := make(chan error) // unbuffered
+go func() {
+    done <- handleHidRPCMessage(message) // may block >1s waiting for queue
+}()
+select {
+case err := <-done:
+    // fast path
+case <-time.After(1 * time.Second):
+    logger.Warn().Msg("HID RPC handler timed out")
+    // worker is still running; it will eventually try to send to `done`,
+    // but nobody is reading → worker goroutine leaks indefinitely
+}
+```
+
+**Fix — buffered completion channel:**
+
+```go
+done := make(chan error, 1) // buffered so the worker's send never blocks
+go func() {
+    done <- handleHidRPCMessage(message)
+}()
+select {
+case err := <-done:
+    // normal completion
+case <-time.After(1 * time.Second):
+    // Downgrade the timeout log for keyboard-macro messages: with blocking
+    // backpressure the timeout is now an expected, benign signal that the
+    // backend is absorbing flow control, not a fault.
+    if message.Type() == hidrpc.TypeKeyboardMacroReport {
+        logger.Debug().Msg("HID RPC keyboard-macro enqueue took >1s (backpressure)")
+    } else {
+        logger.Warn().Msg("HID RPC handler timed out")
+    }
+    // Worker finishes later and sends into the buffered channel with no
+    // blocker; the send is a no-op from the handler's perspective.
+}
+```
+
+**Exact current structure of `onHidMessage` is not in the research report.** The implementation task verifies the actual pattern and applies the minimum-delta fix (buffered channel for the completion signal; downgrade the timeout log for `TypeKeyboardMacroReport` specifically). If the current implementation already uses a close-based pattern or `sync.Once`-protected send, the implementer chooses the form that matches existing style — the requirement is simply that the worker cannot block forever on a dropped done channel.
+
+**Why this is in scope for Phase 1:** the 4096 → 64 queue change in the same PR creates the conditions for this timeout to fire routinely. Shipping one without the other would risk a measurable goroutine-leak regression as soon as a user starts pasting large text.
 
 ### Backend: `internal/usbgadget/hid_keyboard.go:365-382` — #34 UpdateKeysDown guard
 
@@ -221,54 +346,100 @@ func (u *UsbGadget) KeyboardReport(modifier byte, keys []byte) error {
 
 ### Frontend: `ui/src/hooks/useKeyboard.ts`
 
-#### 1. New helper: `waitForPasteDrain`
+#### 1. New helper: `waitForPasteDrain` — subscribe-first with arm window
+
+The naive "fast-return if `!isPasteInProgress`" fast-path has a late-start race: `executePasteText` finishes its send loop before backend `State:true` has arrived, the store still reads `false`, the helper returns immediately, and the caller reports success while the paste is actually still queued and running. The fix is to subscribe first and only return early if the store stayed false throughout a short **arm window** — giving backend `State:true` a chance to land before we start deciding whether the paste is "in progress".
 
 Add a module-scoped async helper (not a React hook — it takes state via getters/subscribers, so it can be a plain function):
 
 ```typescript
 type PasteDrainMode = "required" | "bestEffort";
 
+const DEFAULT_ARM_WINDOW_MS = 200;
+const DEFAULT_SETTLE_MS = 500;
+
 async function waitForPasteDrain(
   mode: PasteDrainMode,
   timeoutMs: number,
   signal?: AbortSignal,
-  settleMs: number = 500,
+  settleMs: number = DEFAULT_SETTLE_MS,
+  armWindowMs: number = DEFAULT_ARM_WINDOW_MS,
 ): Promise<void> {
-  if (!useHidStore.getState().isPasteInProgress) {
-    return;
-  }
   return new Promise<void>((resolve, reject) => {
+    let done = false;
+    let armHandle: ReturnType<typeof setTimeout> | undefined;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-    const onAbort = () => {
-      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+
+    const cleanup = () => {
+      if (armHandle) clearTimeout(armHandle);
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      signal?.removeEventListener("abort", onAbort);
       unsubscribe();
-      reject(new Error("Paste execution aborted"));
     };
+    const resolveClean = () => {
+      if (done) return;
+      done = true;
+      cleanup();
+      setTimeout(resolve, settleMs); // observed drain → host USB settle
+    };
+    const resolveImmediate = () => {
+      if (done) return;
+      done = true;
+      cleanup();
+      resolve(); // no drain observed → no settle needed
+    };
+    const rejectErr = (err: Error) => {
+      if (done) return;
+      done = true;
+      cleanup();
+      reject(err);
+    };
+    const onAbort = () => rejectErr(new Error("Paste execution aborted"));
+
+    // Subscribe FIRST so we never miss a State:true that arrives between
+    // now and the arm-window check.
     const unsubscribe = useHidStore.subscribe((state) => {
       if (!state.isPasteInProgress) {
-        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
-        signal?.removeEventListener("abort", onAbort);
-        unsubscribe();
-        setTimeout(resolve, settleMs);
+        resolveClean();
       }
     });
     signal?.addEventListener("abort", onAbort, { once: true });
+
     timeoutHandle = setTimeout(() => {
-      unsubscribe();
-      signal?.removeEventListener("abort", onAbort);
       if (mode === "required") {
-        reject(new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`));
+        rejectErr(
+          new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`),
+        );
       } else {
-        resolve();
+        resolveImmediate(); // bestEffort: treat timeout as success, no settle
       }
     }, timeoutMs);
+
+    // Arm window — only in bestEffort mode. If isPasteInProgress is still
+    // false after armWindowMs, assume the paste never materialized (zero
+    // batches, immediate error, send loop that did nothing) and resolve
+    // without waiting for the full timeout. In required mode the caller
+    // is asserting "a paste is in progress or about to start" so we wait
+    // the full timeout budget and reject if nothing drains.
+    if (mode === "bestEffort" && !useHidStore.getState().isPasteInProgress) {
+      armHandle = setTimeout(() => {
+        armHandle = undefined;
+        if (!useHidStore.getState().isPasteInProgress) {
+          resolveImmediate();
+        }
+        // else: a State:true arrived during the arm window; the subscription
+        // will fire when the matching State:false lands.
+      }, armWindowMs);
+    }
   });
 }
 ```
 
-- `"bestEffort"` — resolves on timeout; preserves current final-settle UX
-- `"required"` — rejects on timeout; used by #38's chunk boundaries in Phase 2 (call sites added there, not here)
-- Both modes preserve the existing 500ms settle delay after a clean drain signal (the current `setTimeout(resolve, 500)` in `executePasteText`)
+- **`"bestEffort"`** — resolves on timeout or on an unarmed arm window; preserves current final-settle UX. Used by Phase 1's final-drain call site in `executePasteText`.
+- **`"required"`** — rejects on timeout; never takes the arm-window fast path. Reserved for #38's chunk boundaries in Phase 2. **No `"required"` call sites are added in Phase 1.**
+- Settle delay (`500ms`) only runs on **observed** clean drain. Timeout and arm-window early return skip the settle (there is nothing to settle for).
+
+**Why subscribe before the arm window?** The subscription is cheap (a Zustand listener) and catches any `State:true` that arrives between the helper's entry and the arm-window resolution. If `State:true` lands during the arm window, the subscription sees it, notes `isPasteInProgress=true` (doesn't resolve), and the arm-window callback sees the non-false state and defers to the subscription. If `State:true` never lands, the arm window resolves. Either way, no paste session is silently dropped.
 
 #### 2. Replace the inline drain wait in `executePasteText`
 
@@ -341,23 +512,23 @@ Frontend sees: `State:true` → `State:false`. Balanced.
 Frontend sees: `State:true` → `State:false`. Balanced across both macros.
 
 **Scenario C — non-paste macro runs concurrently with paste:**
-1. Enqueuer A (paste M1): `Add(1)` → 1, emit `State:true`, send OK
+1. Enqueuer A (paste M1, `isPaste=true`): `Add(1)` → 1, emit `State:true`, send OK
 2. Enqueuer B (button macro M2, `isPaste=false`): no `pasteDepth` touch, send OK
-3. Drain: runs M1, `Add(-1)` → 1 (wait — this doesn't match; pasteDepth was 1, so `Add(-1)` → 0 here)
+3. Drain: runs M1, `Add(-1)` → 0, emit `State:false`
+4. Drain: runs M2, no `pasteDepth` touch, no emit
 
-Let me retrace: step 1 leaves `pasteDepth = 1`. Step 2 doesn't touch it. Step 3 drain runs M1, `Add(-1)` → 0, emit `State:false`. Step 4 drain runs M2, no `pasteDepth` touch, no emit.
+Frontend sees: `State:true` → `State:false`. The button macro produces no state traffic. Balanced, and the paste's drain wait isn't disturbed by the button macro — fixing the live bug reported in #42.
 
-Frontend sees: `State:true` → `State:false`. The button macro produces no state traffic. Balanced, and the paste's drain wait isn't disturbed by the button macro.
-
-**Scenario D — enqueue rollback on cancelled context:**
+**Scenario D — enqueue rollback on rotated enqueue context (user cancel):**
 1. `pasteDepth = 0`
-2. Enqueuer A: `Add(1)` → 1, emit `State:true`
-3. Enqueuer A: channel is full, blocks on send
-4. Session context cancelled
-5. Enqueuer A: `select` takes `ctx.Done()` branch, `Add(-1)` → 0, emit `State:false`
-6. Enqueuer A returns `ctx.Err()`
+2. Enqueuer A: snapshots `macroEnqueueCtx` → `ctxA`
+3. Enqueuer A: `Add(1)` → 1, emit `State:true` to A's session
+4. Enqueuer A: channel is full, blocks on send against `ctxA.Done()`
+5. User presses cancel → `cancelAndDrainMacroQueue` cancels `ctxA` and installs a fresh `macroEnqueueCtx`
+6. Enqueuer A: `select` takes `ctxA.Done()` branch, `Add(-1)` → 0, emit `State:false` to A's session
+7. Enqueuer A returns `ctxA.Err()` to its caller
 
-Frontend sees: `State:true` → `State:false`. Balanced. No depth leak. If the session is gone, the frontend won't receive either message, which is fine — the frontend's drain-wait rejects via the abort signal path anyway.
+Frontend sees: `State:true` → `State:false`. Balanced. No depth leak. The frontend's drain-wait will resolve (observed drain) or time out (bestEffort) — either way the user's cancel translates into a clean paste-session close.
 
 **Scenario E — enqueue rollback while others are still running:**
 1. `pasteDepth = 0`
@@ -385,26 +556,13 @@ Steps 5 and 6 race. Both are atomic `Add`s with return-value edge detection. Exa
 
 Whichever op observes the final 0 is the one that emits. No double-emit, no miss, no negative depth. Frontend sees exactly one `State:false` for the cancelled session.
 
-**What about adversarial ordering with a new enqueue mid-cancel?**
-- pre-state: `pasteDepth = 5`, 1 running + 4 queued
-- Sweep: `Add(-4)` → 1
-- New enqueue X: `Add(1)` → 2, emits nothing (not 0→1), starts blocking send
-- Drain: `Add(-1)` → 1, does not emit
-- Sweep: returns (queue was empty when it swept)
-- X: send succeeds. X is now in the queue alone with `pasteDepth = 1`.
-- Drain wakes up, runs X, `Add(-1)` → 0, emits `State:false`
+**Scenario G — new paste begins after sweep completes:**
+1. Pre-state: `pasteDepth = 1`, the in-flight macro is the last one of the current session
+2. Sweep runs (queue empty, `discardedPaste = 0`, no emit)
+3. Drain: `Add(-1)` → 0, emit `State:false`
+4. New enqueue Y: snapshots the **fresh** enqueue ctx, `Add(1)` → 1, emits `State:true`, sends OK
 
-Frontend sees: `State:true` (from A's original enqueue way before) → `State:false` (from X's drain). Balanced. No gap even across a user cancel.
-
-But wait — X emitted no `State:true`. Is that a problem? The session was already "open" from A's earlier emit, and the frontend views this as one continuous session. Once the session closes (via X's drain decrement), it's closed. No inconsistency for the frontend.
-
-**What if the entire paste completes during sweep and a new paste starts?**
-- pre-state: `pasteDepth = 1`, the in-flight M is the last one, about to finish
-- Sweep: queue empty, `discardedPaste = 0`, sweep does nothing
-- Drain: `Add(-1)` → 0, emits `State:false`
-- New enqueue Y: `Add(1)` → 1, emits `State:true`, sends OK
-
-Frontend sees: `...` → `State:false` → `State:true` → (eventually) `State:false`. Two sessions, each balanced. ✓
+Frontend sees: `State:false` (closing the cancelled session) → `State:true` (opening the new paste) → eventually `State:false` (closing the new paste). Two sessions, each balanced. The fresh enqueue ctx guarantees that Y cannot be unblocked by the previous cancel — only a future `cancelAndDrainMacroQueue` can cancel Y.
 
 ### Invariant 4: no negative depth
 
@@ -422,24 +580,38 @@ Given that (a) all decrement sites check `Add(-n) == 0` rather than `<= 0`, (b) 
 
 ### Runtime
 
-Device testing is deferred until after PR review. The verification loop in Step 6 of the workflow runs only the static checks. A plan-level "smoke test" note in the PR body advises the reviewer that runtime validation (100k-char paste, button-macro concurrent with paste, cancel mid-paste) is a post-merge activity.
+Device testing is deferred until after PR review. The verification loop in Step 6 of the workflow runs only the static checks. A plan-level "smoke test" note in the PR body advises the reviewer that the following runtime scenarios are post-merge validation:
+
+- 100k-char paste in both `reliable` and `fast` profiles — verify no stalls, no stuck `isPasteInProgress`
+- Button macro (e.g., from `MacroBar.tsx`) fired concurrently with a paste — verify paste drain wait does not resolve prematurely
+- Cancel mid-paste with a queue ≥32 items deep — verify blocked enqueuers wake and return errors, `State:false` fires exactly once, no goroutine leak (check `goroutine` count before/after with a debug endpoint if available)
+- `onHidMessage` 1-second timeout fires on a very busy host — verify no logs flood in `Warn` (should be `Debug` for keyboard-macro) and no goroutine leak
+- Failed HID write (simulatable by unplugging the USB gadget mid-paste, if practical) — verify `keysDownState` is not poisoned; a subsequent working keypress is reported correctly
 
 ## Out of scope (explicit non-goals)
 
-- Per-session paste IDs / `pasteSessionId` field on messages — #42 body defers these; not needed for depth semantics
-- Chunk boundaries for large pastes (#38, Phase 2) — relies on `waitForPasteDrain("required", ...)` call sites, added in Phase 2
+- Per-session paste IDs / `pasteSessionId` field on messages — #42 body defers these; not needed for depth semantics. (See the "Known protocol limitation" section below for what this defers.)
+- Chunk boundaries for large pastes (#38, Phase 2) — `waitForPasteDrain("required", ...)` call sites are added in Phase 2, not here; `"required"` ships in Phase 1 with zero call sites
 - Profile retuning (#40, Phase 3a) — `pasteBatches.ts` / `pasteMacro.ts` untouched
-- Timer reuse in the drain loop (#43, Phase 3b) — `jsonrpc.go` timer allocations not part of this PR
-- Timed-sequence HID writer (#44, Phase 4) — `hid_keyboard.go` write path not restructured; only the #34 guard lands
+- Timer reuse in the drain loop (#43, Phase 3b) — `jsonrpc.go` timer allocations not optimized in this PR
+- Timed-sequence HID writer (#44, Phase 4) — `hid_keyboard.go` write path not restructured; only the #34 early-return guard lands
 - Frontend vitest harness (#45, Phase 5) — no test infrastructure added
-- Any backend changes outside the three functions listed in the touch list
+- Any backend changes outside the functions listed in the touch list above
 
-## Open question for the implementation task
+## Known protocol limitation: trailing batches after cancel
 
-**Where does `ctx` come from at `hidrpc.go:37`?** The research report did not capture the surrounding 30 lines of `handleHidRPCMessage`. The Step 5 implementation task must verify that:
+**This is a documented limitation, not a bug to fix in Phase 1.**
 
-1. `handleHidRPCMessage` (or its caller) receives a context.Context bound to the session lifetime
-2. That context is passed through to `rpcExecuteKeyboardMacro`
-3. No existing code path relies on `rpcExecuteKeyboardMacro` being callable without a context (it should not — this is the only caller per the research)
+Explicit paste cancel is best-effort for batches the browser has already sent over the WebRTC data channel but the backend has not yet consumed into `macroQueue`. A trailing batch can arrive at the backend *after* `cancelAndDrainMacroQueue` has run, and because there is no wire-level paste-session identity (no `pasteSessionId` field on `KeyboardMacroReport`), the backend cannot distinguish "a trailing batch from the cancelled paste" from "the first batch of a new paste the user just started". The backend treats any arriving paste macro as a live paste and processes it.
 
-If the current handler does not accept a context today, the implementer adds one. The plan-writing step (Step 4) will include a small subtask for this discovery.
+Concretely, after a user cancel the following sequence can occur:
+1. Frontend send loop finishes sending batches 1..N to the WebRTC data channel
+2. User clicks cancel; frontend's `AbortSignal` fires, `executePasteText` returns
+3. `cancelAndDrainMacroQueue` runs on the backend, rotates the enqueue ctx, cancels the in-flight macro, sweeps the queue, emits `State:false`
+4. Batches N-3..N (still in flight over SCTP, not yet consumed by the HID RPC handler) arrive
+5. Backend re-enters paste mode for these trailing batches: `pasteDepth` goes 0→1→...→0 again, `State:true` then `State:false` fire
+6. Host sees a short burst of keystrokes after the user clicked cancel
+
+Paste-depth semantics fix the **internal state race** (backend and frontend agree on "are we in a paste"), but they cannot fix **stale post-cancel traffic** without adding wire-level paste identity. That is explicitly deferred to a future session-ID phase.
+
+**QA note:** a trailing burst of keystrokes after cancel, on the order of one or two batches, is an expected protocol limitation — not evidence that paste-depth accounting is broken. Reproducing it requires a large paste in fast profile so there are enough in-flight SCTP frames to outlive the cancel round-trip.

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -90,14 +90,31 @@ func onHidMessage(msg hidQueueMessage, session *Session) {
 
 	t := time.Now()
 
-	r := make(chan interface{})
+	// Buffered completion channel so the worker goroutine's send never blocks.
+	// With the shallow 64-slot macroQueue and blocking backpressure on full,
+	// handleHidRPCMessage can legitimately take longer than the 1-second
+	// timeout below. If we left this unbuffered, the worker would block forever
+	// on the done-send once the timeout fired, leaking a goroutine per
+	// timed-out message.
+	//
+	// chan struct{} rather than chan interface{} — the channel is a pure
+	// done-signal, no payload ever flows through it.
+	r := make(chan struct{}, 1)
 	go func() {
 		handleHidRPCMessage(message, session)
-		r <- nil
+		r <- struct{}{}
 	}()
 	select {
 	case <-time.After(1 * time.Second):
-		scopedLogger.Warn().Msg("HID RPC message timed out")
+		// Downgrade the timeout log for keyboard-macro messages: with blocking
+		// backpressure from the shallow macroQueue, enqueue taking >1s is an
+		// expected, benign signal that the backend is absorbing flow control,
+		// not a fault.
+		if message.Type() == hidrpc.TypeKeyboardMacroReport {
+			scopedLogger.Debug().Msg("HID RPC keyboard-macro handler took >1s (backpressure)")
+		} else {
+			scopedLogger.Warn().Msg("HID RPC message timed out")
+		}
 	case <-r:
 		scopedLogger.Debug().Dur("duration", time.Since(t)).Msg("HID RPC message handled")
 	}

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -34,7 +34,7 @@ func handleHidRPCMessage(message hidrpc.Message, session *Session) {
 			logger.Warn().Err(err).Msg("failed to get keyboard macro report")
 			return
 		}
-		rpcErr = rpcExecuteKeyboardMacro(keyboardMacroReport.Steps)
+		rpcErr = rpcExecuteKeyboardMacro(session, keyboardMacroReport.Steps, keyboardMacroReport.IsPaste)
 	case hidrpc.TypeCancelKeyboardMacroReport:
 		rpcCancelKeyboardMacro()
 		return

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -376,10 +376,14 @@ func (u *UsbGadget) KeyboardReport(modifier byte, keys []byte) error {
 	u.RecordWriteResult(err)
 	if err != nil {
 		u.log.Warn().Uint8("modifier", modifier).Uints8("keys", keys).Msg("Could not write keyboard report to hidg0")
+		// Do NOT update internal key state on a failed write — otherwise
+		// keysDownState diverges from what the host actually received and
+		// subsequent reports will be based on a poisoned snapshot.
+		return err
 	}
 
 	u.UpdateKeysDown(modifier, keys)
-	return err
+	return nil
 }
 
 const (

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1008,40 +1008,100 @@ func rpcSetLocalLoopbackOnly(enabled bool) error {
 	return nil
 }
 
+// macroQueueDepth is the buffered capacity of macroQueue. Keep this shallow so
+// the frontend's bufferedAmount flow control provides real backpressure — a
+// deep queue hides the sender's view of how far behind the backend has fallen.
+// See docs/superpowers/specs/2026-04-08-paste-pipeline-flow-control-design.md.
+const macroQueueDepth = 64
+
+// queuedMacro wraps a macro batch with its paste flag and origin session so
+// drainMacroQueue and cancelAndDrainMacroQueue can report state messages back
+// to the session that enqueued the paste, not whichever global currentSession
+// happens to be live when the edge fires.
+type queuedMacro struct {
+	steps   []hidrpc.KeyboardMacroStep
+	isPaste bool
+	session *Session
+}
+
 var (
 	// macroQueue is the channel-based FIFO for keyboard macro batches.
 	// The drain goroutine is the sole consumer; rpcExecuteKeyboardMacro is the producer.
-	macroQueue chan []hidrpc.KeyboardMacroStep
+	macroQueue chan queuedMacro
 
 	// macroCurrentCancel cancels the currently executing macro in the drain goroutine.
 	macroCurrentCancel context.CancelFunc
 	macroLock          sync.Mutex
 	macroQueueOnce     sync.Once
+
+	// pasteDepth is the atomic count of accepted/executing paste macros.
+	// Incremented by rpcExecuteKeyboardMacro before the blocking channel send,
+	// decremented by drainMacroQueue after each paste macro finishes, by
+	// rpcExecuteKeyboardMacro's rollback branch on cancelled enqueue, and by
+	// cancelAndDrainMacroQueue for each paste macro swept out of the queue.
+	// State:true emits on the 0→1 transition; State:false emits on the 1→0
+	// transition. Non-paste macros never touch this counter.
+	pasteDepth atomic.Int32
+
+	// macroEnqueueCtx is the cancellation context for blocking enqueues.
+	// It is owned by the macro queue (not by any handler or session) and is
+	// rotated by cancelAndDrainMacroQueue so that enqueuers blocked on a full
+	// macroQueue wake up, roll back their paste-depth reservation, and return
+	// ctx.Err() to the caller.
+	macroEnqueueCtx    context.Context
+	macroEnqueueCancel context.CancelFunc
+	macroEnqueueMu     sync.Mutex
 )
 
-// startMacroQueue creates the macro queue channel and starts the drain goroutine.
-// Called when the first WebRTC session is established.
+// startMacroQueue creates the macro queue channel, the enqueue cancellation
+// context, and starts the drain goroutine. Idempotent — safe to call from
+// every rpcExecuteKeyboardMacro invocation.
 func startMacroQueue() {
 	macroQueueOnce.Do(func() {
-		macroQueue = make(chan []hidrpc.KeyboardMacroStep, 4096)
+		macroQueue = make(chan queuedMacro, macroQueueDepth)
+		macroEnqueueCtx, macroEnqueueCancel = context.WithCancel(context.Background())
 		go drainMacroQueue()
 	})
 }
 
-// drainMacroQueue is the sole consumer of macroQueue. It executes each macro
-// sequentially and reports completion state to the frontend after each one.
-func drainMacroQueue() {
-	for macro := range macroQueue {
-		macroID := keyboardMacroSequence.Add(1)
-		logger.Info().Uint64("macro_id", macroID).Int("step_count", len(macro)).Msg("executing queued keyboard macro")
+// currentEnqueueCtx returns the active enqueue cancellation context under
+// lock. Enqueuers snapshot this once at entry; if cancelAndDrainMacroQueue
+// rotates the context while they're blocked on send, the snapshot they hold
+// still fires on the old Cancel and unblocks them cleanly.
+func currentEnqueueCtx() context.Context {
+	macroEnqueueMu.Lock()
+	defer macroEnqueueMu.Unlock()
+	return macroEnqueueCtx
+}
 
-		// Report macro start (frontend uses this for isPasteInProgress)
-		if currentSession != nil {
-			currentSession.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
-				State:   true,
-				IsPaste: true,
-			})
-		}
+// emitPasteState reports a paste-session state transition to the origin
+// session. Callers must only invoke this on the 0→1 or 1→0 transition
+// (i.e., when the relevant pasteDepth.Add return value equals 1 or 0
+// respectively). If the session is nil (origin session torn down between
+// enqueue and drain), this silently no-ops — the frontend on the new
+// session will reconcile state through its own fresh subscription.
+func emitPasteState(session *Session, state bool) {
+	if session == nil {
+		return
+	}
+	session.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
+		State:   state,
+		IsPaste: true,
+	})
+}
+
+// drainMacroQueue is the sole consumer of macroQueue. It executes each macro
+// sequentially. Paste-session state transitions (State:true / State:false) are
+// emitted on atomic pasteDepth 0↔1 edges, not per macro — see rpcExecuteKeyboardMacro
+// for the 0→1 emit and the post-run block below for the 1→0 emit.
+func drainMacroQueue() {
+	for item := range macroQueue {
+		macroID := keyboardMacroSequence.Add(1)
+		logger.Info().
+			Uint64("macro_id", macroID).
+			Int("step_count", len(item.steps)).
+			Bool("is_paste", item.isPaste).
+			Msg("executing queued keyboard macro")
 
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -1049,7 +1109,7 @@ func drainMacroQueue() {
 		macroCurrentCancel = cancel
 		macroLock.Unlock()
 
-		err := rpcDoExecuteKeyboardMacro(ctx, macro)
+		err := rpcDoExecuteKeyboardMacro(ctx, item.steps)
 		if err != nil {
 			logger.Warn().Uint64("macro_id", macroID).Err(err).Msg("queued keyboard macro failed")
 		} else {
@@ -1062,13 +1122,13 @@ func drainMacroQueue() {
 
 		cancel()
 
-		// Report per-macro completion (frontend uses this for draining phase detection)
-		s := hidrpc.KeyboardMacroState{
-			State:   false,
-			IsPaste: true,
-		}
-		if currentSession != nil {
-			currentSession.reportHidRPCKeyboardMacroState(s)
+		// Paste-depth decrement + conditional emit on the 1→0 transition.
+		// Non-paste macros never touch pasteDepth or emit state.
+		if item.isPaste {
+			if pasteDepth.Add(-1) == 0 {
+				logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 1->0 (drain complete)")
+				emitPasteState(item.session, false)
+			}
 		}
 
 		// Inter-macro drain delay: gives the host USB stack time to process
@@ -1079,9 +1139,29 @@ func drainMacroQueue() {
 	}
 }
 
-// cancelAndDrainMacroQueue cancels the currently executing macro and discards
-// all queued macros. Called on session teardown, session takeover, and explicit cancel.
+// cancelAndDrainMacroQueue cancels the currently executing macro, wakes any
+// enqueuers blocked on a full macroQueue, and discards all queued macros.
+// Called on session teardown, session takeover, and explicit cancel.
+//
+// The steps run in order: (1) rotate the enqueue context so blocked enqueuers
+// wake and roll back cleanly, (2) cancel the in-flight macro so drainMacroQueue
+// returns from rpcDoExecuteKeyboardMacro and hits its post-run decrement
+// block, (3) sweep the channel and atomically subtract the discarded paste
+// count from pasteDepth, emitting State:false on a 1→0 transition.
 func cancelAndDrainMacroQueue() {
+	// Step 1: Rotate the enqueue context. Cancel the current one to wake any
+	// enqueuers blocked on macroQueue send; install a fresh context for future
+	// enqueues.
+	macroEnqueueMu.Lock()
+	if macroEnqueueCancel != nil {
+		macroEnqueueCancel()
+	}
+	macroEnqueueCtx, macroEnqueueCancel = context.WithCancel(context.Background())
+	macroEnqueueMu.Unlock()
+
+	// Step 2: Cancel the in-flight macro (if any). drainMacroQueue's post-run
+	// block will decrement pasteDepth and emit State:false if that decrement is
+	// the 1→0 transition.
 	macroLock.Lock()
 	if macroCurrentCancel != nil {
 		macroCurrentCancel()
@@ -1089,35 +1169,82 @@ func cancelAndDrainMacroQueue() {
 	}
 	macroLock.Unlock()
 
-	// Drain any queued macros without executing them
-	if macroQueue != nil {
-		drained := 0
-		for {
-			select {
-			case <-macroQueue:
-				drained++
-			default:
-				if drained > 0 {
-					logger.Info().Int("count", drained).Msg("drained queued keyboard macros")
-				}
-				return
+	// Step 3: Sweep any remaining items out of the channel without running them.
+	// Track the session of the last paste item we saw so that if our sweep closes
+	// the paste session (1→0), we emit State:false to the right session.
+	if macroQueue == nil {
+		return
+	}
+	var discardedTotal int
+	var discardedPaste int32
+	var lastPasteSession *Session
+	draining := true
+	for draining {
+		select {
+		case item := <-macroQueue:
+			discardedTotal++
+			if item.isPaste {
+				discardedPaste++
+				lastPasteSession = item.session
 			}
+		default:
+			draining = false
+		}
+	}
+	if discardedTotal > 0 {
+		logger.Info().Int("count", discardedTotal).Msg("drained queued keyboard macros")
+	}
+	if discardedPaste > 0 {
+		logger.Debug().Int32("discarded_paste", discardedPaste).Msg("cancel sweep discarded paste macros")
+		if pasteDepth.Add(-discardedPaste) == 0 {
+			logger.Debug().Msg("paste-depth 1->0 (cancel sweep)")
+			emitPasteState(lastPasteSession, false)
 		}
 	}
 }
 
-func rpcExecuteKeyboardMacro(macro []hidrpc.KeyboardMacroStep) error {
+func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep, isPaste bool) error {
 	macroID := keyboardMacroSequence.Add(1)
-	logger.Info().Uint64("macro_id", macroID).Int("step_count", len(macro)).Msg("enqueuing keyboard macro")
+	logger.Info().
+		Uint64("macro_id", macroID).
+		Int("step_count", len(steps)).
+		Bool("is_paste", isPaste).
+		Msg("enqueuing keyboard macro")
 
 	// Ensure queue is started (idempotent)
 	startMacroQueue()
 
-	// Blocking enqueue. If the channel is full (4096 batches), this blocks
-	// until the drain goroutine frees a slot, creating backpressure through
-	// the SCTP stack to the frontend's bufferedAmount flow control.
-	macroQueue <- macro
-	return nil
+	// Snapshot the current enqueue cancellation context. If
+	// cancelAndDrainMacroQueue rotates the context while we're blocked on
+	// send, the snapshot we hold still fires on the old Cancel and unblocks
+	// us cleanly.
+	ctx := currentEnqueueCtx()
+
+	// Pre-increment: reserve a paste-depth slot BEFORE we attempt to enqueue.
+	// Emit State:true if this Add is the 0→1 transition.
+	if isPaste {
+		if pasteDepth.Add(1) == 1 {
+			logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 0->1 (enqueue)")
+			emitPasteState(session, true)
+		}
+	}
+
+	// Cancellable blocking send. If the enqueue context is cancelled (user
+	// pressed cancel → cancelAndDrainMacroQueue rotated the context) before
+	// the channel accepts the item, roll back the pasteDepth increment and
+	// emit State:false if the rollback is itself the 1→0 transition.
+	select {
+	case macroQueue <- queuedMacro{steps: steps, isPaste: isPaste, session: session}:
+		return nil
+	case <-ctx.Done():
+		if isPaste {
+			if pasteDepth.Add(-1) == 0 {
+				logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 1->0 (enqueue rollback)")
+				emitPasteState(session, false)
+			}
+		}
+		return ctx.Err()
+	}
 }
 
 func rpcCancelKeyboardMacro() {

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -143,7 +143,7 @@ async function waitForPasteDrain(
     // Subscribe FIRST. Every store update runs this callback; we update
     // the `seenTrue` latch on truthy updates and only take the clean-drain
     // exit on a falsy update AFTER seenTrue has been latched.
-    const unsubscribe = useHidStore.subscribe((state) => {
+    const unsubscribe = useHidStore.subscribe(state => {
       if (state.isPasteInProgress) {
         seenTrue = true;
         return;
@@ -169,9 +169,7 @@ async function waitForPasteDrain(
 
     timeoutHandle = setTimeout(() => {
       if (mode === "required") {
-        rejectErr(
-          new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`),
-        );
+        rejectErr(new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`));
       } else {
         // bestEffort: treat timeout as success, skip settle.
         resolveImmediate();

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -61,6 +61,143 @@ export interface ExecutePasteTextOptions {
   onTrace?: (trace: PasteExecutionTrace) => void;
 }
 
+type PasteDrainMode = "required" | "bestEffort";
+
+const PASTE_DRAIN_DEFAULT_ARM_WINDOW_MS = 200;
+const PASTE_DRAIN_DEFAULT_SETTLE_MS = 500;
+
+/**
+ * Wait for a paste session to drain from the backend macro queue.
+ *
+ * Modes:
+ * - "bestEffort" — resolves on timeout or on the arm window (if no paste ever
+ *   started). Preserves the existing final-settle UX from executePasteText.
+ *   Used by Phase 1's final-drain call site.
+ * - "required" — rejects on timeout, never takes the arm-window fast path.
+ *   Reserved for #38's chunk boundaries in Phase 2. No Phase 1 call sites.
+ *
+ * Correctness: the helper subscribes to useHidStore BEFORE sampling the
+ * current isPasteInProgress value, and latches a local `seenTrue` flag.
+ * The clean-drain exit fires only when the subscription observes
+ * isPasteInProgress transition to false AFTER we've already seen it be
+ * true. Without the latch, any unrelated store mutation arriving while
+ * isPasteInProgress is still in its late-start false window would resolve
+ * the wait early — reintroducing a softer version of the race we are
+ * trying to remove.
+ *
+ * In bestEffort mode, if the arm window elapses without isPasteInProgress
+ * ever going true, we assume the paste never materialized (zero batches,
+ * immediate error, send loop that did nothing) and resolve without
+ * waiting for the full timeout.
+ */
+async function waitForPasteDrain(
+  mode: PasteDrainMode,
+  timeoutMs: number,
+  signal?: AbortSignal,
+  settleMs: number = PASTE_DRAIN_DEFAULT_SETTLE_MS,
+  armWindowMs: number = PASTE_DRAIN_DEFAULT_ARM_WINDOW_MS,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let done = false;
+    let seenTrue = false;
+    let armHandle: ReturnType<typeof setTimeout> | undefined;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (armHandle !== undefined) {
+        clearTimeout(armHandle);
+        armHandle = undefined;
+      }
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = undefined;
+      }
+      signal?.removeEventListener("abort", onAbort);
+      unsubscribe();
+    };
+
+    const resolveClean = () => {
+      if (done) return;
+      done = true;
+      cleanup();
+      // Observed drain → host USB settle delay before the caller resumes.
+      setTimeout(resolve, settleMs);
+    };
+
+    const resolveImmediate = () => {
+      if (done) return;
+      done = true;
+      cleanup();
+      resolve();
+    };
+
+    const rejectErr = (err: Error) => {
+      if (done) return;
+      done = true;
+      cleanup();
+      reject(err);
+    };
+
+    const onAbort = () => rejectErr(new Error("Paste execution aborted"));
+
+    // Subscribe FIRST. Every store update runs this callback; we update
+    // the `seenTrue` latch on truthy updates and only take the clean-drain
+    // exit on a falsy update AFTER seenTrue has been latched.
+    const unsubscribe = useHidStore.subscribe((state) => {
+      if (state.isPasteInProgress) {
+        seenTrue = true;
+        return;
+      }
+      if (seenTrue) {
+        resolveClean();
+      }
+    });
+
+    // Now sample the current value. If a state change happened between
+    // subscribe() and getState(), the subscription callback above already
+    // set seenTrue — this assignment is harmlessly redundant in that case.
+    // If no change happened, we pick up whatever the store says right now.
+    seenTrue = useHidStore.getState().isPasteInProgress;
+
+    // Fast-reject if the caller already aborted before we even started.
+    if (signal?.aborted) {
+      rejectErr(new Error("Paste execution aborted"));
+      return;
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    timeoutHandle = setTimeout(() => {
+      if (mode === "required") {
+        rejectErr(
+          new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`),
+        );
+      } else {
+        // bestEffort: treat timeout as success, skip settle.
+        resolveImmediate();
+      }
+    }, timeoutMs);
+
+    // Arm window — bestEffort only, and only if we haven't yet seen a
+    // paste become active. If after armWindowMs the store still says
+    // isPasteInProgress === false AND seenTrue is still false, assume
+    // the paste never materialized and resolve. If the store has gone
+    // true during the window, flip seenTrue and defer to the subscription.
+    if (mode === "bestEffort" && !seenTrue) {
+      armHandle = setTimeout(() => {
+        armHandle = undefined;
+        if (useHidStore.getState().isPasteInProgress) {
+          seenTrue = true;
+          return;
+        }
+        if (!seenTrue) {
+          resolveImmediate();
+        }
+      }, armWindowMs);
+    }
+  });
+}
+
 export default function useKeyboard() {
   const { send } = useJsonRpc();
   const { rpcDataChannel } = useRTCStore();
@@ -472,40 +609,14 @@ export default function useKeyboard() {
           }
         }
 
-        // Wait for backend to finish draining all queued macros.
-        // The drain goroutine sends State:false after each macro completes.
-        // We wait for isPasteInProgress to become false (final completion signal),
-        // with a generous timeout based on the number of batches.
+        // Wait for backend to finish draining all queued macros. The helper
+        // subscribes first (no late-start race) and uses an arm window so a
+        // paste that never materialized doesn't block for the full timeout.
+        // bestEffort mode preserves the current final-settle UX — resolves on
+        // timeout, resolves with a settle delay on clean drain, rejects only
+        // on abort.
         const drainTimeoutMs = Math.max(finalSettleMs, batches.length * 1000);
-        await new Promise<void>((resolve, reject) => {
-          // If paste is already not in progress (e.g. very small paste), resolve immediately
-          if (!useHidStore.getState().isPasteInProgress) {
-            resolve();
-            return;
-          }
-
-          const timeout = setTimeout(() => {
-            unsubscribe();
-            resolve(); // Resolve on timeout rather than reject — batches were sent successfully
-          }, drainTimeoutMs);
-
-          const abortHandler = () => {
-            clearTimeout(timeout);
-            unsubscribe();
-            reject(new Error("Paste execution aborted"));
-          };
-          signal?.addEventListener("abort", abortHandler, { once: true });
-
-          const unsubscribe = useHidStore.subscribe(state => {
-            if (!state.isPasteInProgress) {
-              clearTimeout(timeout);
-              signal?.removeEventListener("abort", abortHandler);
-              unsubscribe();
-              // Small settle delay after final completion for host USB consumption
-              setTimeout(resolve, 500);
-            }
-          });
-        });
+        await waitForPasteDrain("bestEffort", drainTimeoutMs, signal);
       } finally {
         channel.removeEventListener("bufferedamountlow", onLow);
         channel.bufferedAmountLowThreshold = prevThreshold;


### PR DESCRIPTION
## Summary

Phase 1 of the phased paste-reliability rollout. Lands three issue fixes plus two related safety fixes in one coherent PR because the queue-depth change, goroutine-safety fix, and paste-depth semantics are all entangled.

- **#42 paste-depth semantics** — replace per-macro `State:true`/`State:false` emits with edge-triggered semantics driven by `pasteDepth atomic.Int32`. `State:true` fires exactly on the 0→1 transition (enqueue); `State:false` fires exactly on the 1→0 transition (drain post-run, enqueue rollback, or cancel sweep). Non-paste macros (button bindings, on-screen keyboard combos, custom macros) no longer touch `pasteDepth` or produce state-message traffic at all.
- **#48 shallow macro queue** — `macroQueue` capacity drops from `4096` to a named `macroQueueDepth = 64` constant per the approved `2026-04-08-paste-pipeline-flow-control-design` spec, so the frontend bufferedAmount flow control actually provides backpressure instead of being masked by a deep queue.
- **#34 UpdateKeysDown guard** — `KeyboardReport` in `internal/usbgadget/hid_keyboard.go` early-returns on failed `keyboardWriteHidFile`, so internal `keysDownState` cannot diverge from what the host actually received. Cherry-picked from PR #37 without the rest of its pre-pipeline ACK-per-batch model.
- **`onHidMessage` goroutine-leak safety** — the worker goroutine now sends into a buffered `chan struct{}` so the 1-second handler timeout can never strand it. Timeout log downgraded to `Debug` for `TypeKeyboardMacroReport` messages specifically (>1s under blocking backpressure is now expected, not a fault). Must ship with #48 in the same PR because the shallower queue makes the leak measurable.
- **`waitForPasteDrain` helper with `seenTrue` latch** — factored the inline drain wait in `executePasteText` into a module-scoped helper with `required`/`bestEffort` modes and a subscribe-first arm window. The `seenTrue` latch closes the late-start race where an unrelated Zustand store mutation could resolve the wait early because `useHidStore.subscribe(...)` without a selector fires on every store mutation. `required` mode ships with no call sites in Phase 1 — it is reserved for #38 chunk boundaries in Phase 2.

## Architecture highlights

- `rpcExecuteKeyboardMacro(session *Session, steps, isPaste)` takes the origin session explicitly so every `queuedMacro` can report state back to the session that enqueued it, not whichever global `currentSession` happens to be live when the edge fires.
- Enqueue cancellation is anchored on a macro-queue-scoped `macroEnqueueCtx` (not a handler or session context), rotated by `cancelAndDrainMacroQueue` so that enqueuers blocked on a full `macroQueue` wake up, roll back their paste-depth reservation via the `ctx.Done()` branch of the `select`, and return `ctx.Err()` to the caller.
- The cancel-sweep + drain-goroutine race on the final `State:false` emit is resolved by atomicity of `Add` — whichever operation observes the final 0 value is the one that emits, regardless of interleaving. See Scenario F in the design spec.

## #42 Acceptance criteria

- [x] Non-paste macros (button bindings, custom macros) no longer toggle `isPasteInProgress`
- [x] `State:false, IsPaste:true` fires exactly once per paste session, on true queue drain
- [x] `IsPaste` flag preserved end-to-end from frontend HID RPC through queue through state messages
- [x] Frontend drain helper has explicit `required`/`bestEffort` modes; final settle keeps current UX, chunk boundaries reject on timeout (`required` mode shipped, no Phase 1 call sites)
- [x] No regression in existing paste UX (progress, cancel, error reporting)

## Scope constraints respected

- `ui/src/components/popovers/PasteModal.tsx` — **untouched**
- `ui/src/utils/pasteBatches.ts` — **untouched** (Phase 3a scope)
- `ui/src/utils/pasteMacro.ts` — **untouched** (Phase 3a scope; `estimateBatchBytes` imported only)
- `internal/native/` — **untouched**
- `internal/hidrpc/message.go` — **untouched** (`IsPaste` already on the wire for both `KeyboardMacroReport` and `KeyboardMacroState`)
- `rpcDoExecuteKeyboardMacro` in `jsonrpc.go` — **untouched** (per-macro executor is preserved verbatim)
- `PASTE_LOW_WATERMARK` / `PASTE_HIGH_WATERMARK`, the local `waitForDrain` flow-control helper, the `bufferedamountlow` listener, and the `finally`-block cleanup in `executePasteText` — **untouched**
- The 200ms inter-macro `time.Sleep` at the end of `drainMacroQueue` (the fix from PR #41) — **preserved verbatim**
- `go.mod`, `ui/package.json`, `ui/package-lock.json`, `.github/workflows/` — **untouched**

## Test plan

### Static verification (all passed on main)

- `cd ui && npx tsc --noEmit` — exit 0, no output
- `cd ui && npx eslint ./src/hooks/useKeyboard.ts` — 646 errors, **all `prettier/prettier` CRLF** from `core.autocrlf=true` on Windows; **zero non-prettier findings** in the one file Phase 1 touched. The committed blob has zero CR bytes — CRLF is a working-copy artifact of Windows checkout, not a commit artifact.
- `cd ui && npx eslint ./src/**/*.{ts,tsx}` — 26563 prettier errors + 3 pre-existing non-prettier findings in files NOT touched by Phase 1 (`Button.tsx` react-refresh warning, `PasteModal.tsx` setTraceLines-in-effect error, etc.); no new regressions.
- `go build ./...` — exit 0 (cross-compiled `GOOS=linux GOARCH=arm GOARM=7` via `jetkvm/buildkit` Docker container — the canonical dev-deploy build environment per `CLAUDE.md`)
- `go vet ./...` — exit 0
- `go test -c` per package — all 7 test-bearing packages compile cleanly (`kvm`, `internal/confparser`, `internal/ota`, `internal/usbgadget`, `internal/utils`, `internal/websecure`, `pkg/nmlite/udhcpc`). Runtime `go test ./...` cannot run ARM binaries on the amd64 build host; per `CLAUDE.md`, Go tests run on-device via `./dev_deploy.sh -r <IP> --run-go-tests`.

### Runtime validation (post-merge, requires device with HDMI+USB attached)

- [ ] 100k-char paste in both `reliable` and `fast` profiles — verify no stalls, no stuck `isPasteInProgress`, no corrupted text on the target
- [ ] Button macro (e.g., from `MacroBar.tsx`) fired concurrently with a paste — verify the paste's drain wait does not resolve prematurely when the button macro completes
- [ ] Cancel mid-paste with the queue ≥32 items deep — verify blocked enqueuers wake and return errors, `State:false` fires exactly once, no goroutine leak
- [ ] `onHidMessage` 1-second timeout fires under heavy backpressure — verify no `Warn`-level logs flood for keyboard-macro messages (should be `Debug`), and no goroutine leak
- [ ] Failed HID write simulation — verify `keysDownState` is not poisoned; a subsequent working keypress is reported correctly

## Known protocol limitation (documented, not fixed here)

Explicit paste cancel is **best-effort for batches the browser has already sent over the WebRTC data channel but the backend has not yet consumed into `macroQueue`**. A trailing batch can arrive at the backend after `cancelAndDrainMacroQueue` has run, and because there is no wire-level paste-session identity (no `pasteSessionId` field on `KeyboardMacroReport`), the backend treats it as a new paste. A short burst of keystrokes after the user clicks cancel is expected — on the order of one or two batches — and is a protocol limitation, not a paste-depth accounting bug. Adding wire-level paste IDs is explicitly deferred to a future phase. QA should evaluate cancel against internal state consistency, not against "zero keystrokes after cancel".

## Review status

- **In-house review:** `superpowers:code-reviewer` **APPROVE**. Eleven correctness invariants verified against live code with file:line citations (atomic `pasteDepth` edges, session threading, no leak/double-count, rollback-safe enqueue, non-paste macros produce zero state traffic, `IsPaste` end-to-end, `UpdateKeysDown` guard, `onHidMessage` goroutine safety, `seenTrue` latch, arm window, signal-aborted fast-reject). Scope compliance clean — every protected file and region byte-identical to main. Six race walkthroughs from the design spec traced against the actual code.
- **Codex cross-check:** attempted, could not run due to a Windows platform issue. The `codex:rescue` skill companion runtime hits `spawn codex ENOENT` because `child_process.spawn` does not resolve Windows `.cmd` npm shims. Running `codex exec review --base main` directly bypasses the companion but hits a second blocker: codex review plans run `git diff ... && git diff ...` via Windows PowerShell 5.1, which does not support `&&` chaining. PowerShell Core 7 is not installed on this host. Deferred rather than blocked — the in-house review was thorough enough to stand alone for a change this focused.

## Tunable defaults (preserved as named constants for easy retuning)

- `macroQueueDepth = 64` — `jsonrpc.go`
- `PASTE_DRAIN_DEFAULT_ARM_WINDOW_MS = 200` — `ui/src/hooks/useKeyboard.ts`
- `PASTE_DRAIN_DEFAULT_SETTLE_MS = 500` — `ui/src/hooks/useKeyboard.ts`

## Spec and plan

- Spec: `docs/superpowers/specs/2026-04-10-paste-depth-semantics-design.md`
- Plan: `docs/superpowers/plans/2026-04-10-paste-depth-semantics.md`

Closes #42
Closes #48
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
