### PR TITLE
fix(webrtc): recover from send-on-closed-channel race in HID queue teardown

### DIFF
--- a/webrtc.go
+++ b/webrtc.go
@@ -237,10 +237,27 @@ func getOnHidMessageHandler(session *Session, scopedLogger *zerolog.Logger, chan
 
 		queue := session.hidQueue[queueIndex]
 		if queue != nil {
-			queue <- hidQueueMessage{
-				DataChannelMessage: msg,
-				channel:            channel,
-			}
+			// Defensive: session teardown closes session.hidQueue[i] at
+			// webrtc.go:440-443 without holding hidQueueLock, while the pion
+			// readLoop goroutine may deliver one last buffered message from
+			// the wire after the close. The unsynchronized close-vs-send race
+			// produces "send on closed channel". Recover here so a late
+			// message during teardown drops with a warning instead of
+			// panicking the whole app. Proper fix is to serialize close and
+			// send under hidQueueLock — tracked as a follow-up.
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						l.Warn().
+							Interface("recover", r).
+							Msg("hidQueue send panicked (channel closed during session teardown); message dropped")
+					}
+				}()
+				queue <- hidQueueMessage{
+					DataChannelMessage: msg,
+					channel:            channel,
+				}
+			}()
 		} else {
 			l.Warn().Int("queueIndex", queueIndex).Msg("received data in HID RPC message handler, but queue is nil")
 			return


### PR DESCRIPTION
## Summary

Defensive recover on the `hidQueue <-` send at `webrtc.go:240` so a late buffered HID RPC message arriving during session teardown gets dropped with a warning log instead of panicking the whole app.

## Root cause

`webrtc.go:240` is a pre-existing unsynchronized send (introduced 2025-09-18, commit `afb146d7`). The pion `DataChannel.readLoop` goroutine may deliver one last buffered HID RPC message from the wire **after** the session-teardown goroutine has closed `session.hidQueue[i]` at `webrtc.go:440-443`. Both operations happen without holding `hidQueueLock`, so the classic TOCTOU sequence is:

```
T1: queue := session.hidQueue[queueIndex]   // reads ref
T1: if queue != nil { ... }                 // checks non-nil
T2: close(session.hidQueue[i])              // closes the channel
T2: session.hidQueue[i] = nil                // nils the slot
T1: queue <- hidQueueMessage{...}            // PANIC: send on closed channel
```

The race is pre-existing, but PR #49's paste-depth semantics exposed it. The new `cancelAndDrainMacroQueue()` call at `webrtc.go:430` runs as part of session teardown and produces backend activity (enqueue context rotation, in-flight macro cancel, queue sweep) that generates late HID RPC traffic during the teardown window. That widens the race enough to reliably hit on user cancel during a large paste.

## Reproduced

On a deployed PR #49 build, clicking cancel mid-paste triggered:

```
panic: send on closed channel

goroutine 218 [running]:
github.com/jetkvm/kvm.newSession.func2.getOnHidMessageHandler.4({0x0, {0x2f76500, 0x4aa, 0x500}})
    github.com/jetkvm/kvm/webrtc.go:240 +0x2d4
github.com/pion/webrtc/v4.(*DataChannel).onMessage(...)
    github.com/pion/webrtc/v4@v4.2.1/datachannel.go:327 +0x74
github.com/pion/webrtc/v4.(*DataChannel).readLoop(...)
    github.com/pion/webrtc/v4@v4.2.1/datachannel.go:432 +0x160
```

Device entered failsafe mode after the crash.

## Fix

Wrap the `hidQueue <-` send in an IIFE with `defer/recover`. A late message during teardown now drops with a warning log instead of crashing the process. The dropped message is on a doomed session-teardown path and would have been lost anyway.

```go
func() {
    defer func() {
        if r := recover(); r != nil {
            l.Warn().
                Interface("recover", r).
                Msg("hidQueue send panicked (channel closed during session teardown); message dropped")
        }
    }()
    queue <- hidQueueMessage{
        DataChannelMessage: msg,
        channel:            channel,
    }
}()
```

## This is a bandaid

The proper fix is to serialize `close()` (at lines 440-443) and `<-` (at line 240) under `hidQueueLock`. That requires careful lock-ordering review because the send is on the hot HID RPC path and any additional lock contention could have fairness implications for the readLoop. Tracked as a follow-up issue (link will be added when filed).

## Scope

- **Files changed:** `webrtc.go` only, +21/-4
- **No behavior change** outside the race window — the send still happens normally on the success path
- **No Phase 1 changes touched** — this is purely a defensive wrapper on pre-existing code

## Test plan

- [x] `go build ./...` — exit 0 (cross-compiled via `jetkvm/buildkit` ARM container)
- [x] `go vet ./...` — exit 0
- [x] Deployed to device via `./dev_deploy.sh -r 192.168.1.36 -i --skip-native-build --skip-ui-build`
- [x] Device back to `[app] ready` (out of failsafe mode) with binary revision `1c97668ec161eb3a316f46443b3bfd1468e5d9c2`
- [x] Subsequent paste+cancel test on hotfix build: no new Go panic, no new crashdump file written. Earlier session showed an unrelated reboot under load (likely watchdog, not a Go crash), tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
