### PR TITLE
fix(paste): derive profile byte caps from step counts (closes #40)

### DIFF
--- a/docs/superpowers/plans/2026-04-11-paste-profile-derived-constants.md
+++ b/docs/superpowers/plans/2026-04-11-paste-profile-derived-constants.md
@@ -1,0 +1,228 @@
+# Phase 3a — Derived-Constant Paste Profiles — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace hardcoded magic-number byte caps in `PASTE_PROFILES` with a derivation path (`deriveProfile` helper) that computes `maxBytesPerBatch` from `estimateBatchBytes(maxStepsPerBatch) + HEADROOM_BYTES`, and enforce the invariant at module load via `assertProfilesReachable`, so `fast` packs more steps per batch than `reliable` as intended.
+
+**Architecture:** Single-file rewrite of `ui/src/utils/pasteBatches.ts`. Import `estimateBatchBytes` from `./pasteMacro` (already exported). Add `HEADROOM_BYTES` constant, `deriveProfile()` helper, `assertProfilesReachable()` load-time check. Profile values: `reliable=deriveProfile(128, 3)`, `fast=deriveProfile(256, 2)`. The `PasteProfile` interface and `PasteProfileName` type export remain identical in shape so consumers in `PasteModal.tsx`, `useKeyboard.ts`, and `pasteMacro.ts` need zero changes.
+
+**Tech Stack:** TypeScript 5, React 18, Vite. No new dependencies. Frontend only — Go side untouched.
+
+**Spec:** `docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md`
+
+**Scope lock (from spec §1 touch list):**
+- **Touch:** `ui/src/utils/pasteBatches.ts` (single file)
+- **Forbidden:** `ui/src/utils/pasteMacro.ts`, `ui/src/hooks/useKeyboard.ts`, `ui/src/components/popovers/PasteModal.tsx`, `package.json`, all Go sources
+
+---
+
+## Task 1: Rewrite `pasteBatches.ts` with derived constants and load-time assertion
+
+**Files:**
+- Modify: `ui/src/utils/pasteBatches.ts` (entire file, 12 lines → ~50 lines)
+- Import-only (no modification): `ui/src/utils/pasteMacro.ts` (for `estimateBatchBytes` at line 36)
+
+### Current state (for reference — do not write this)
+
+```typescript
+interface PasteProfile {
+  maxStepsPerBatch: number;
+  maxBytesPerBatch: number;
+  keyDelayMs: number;
+}
+
+export const PASTE_PROFILES = {
+  reliable: { maxStepsPerBatch: 128, maxBytesPerBatch: 1200, keyDelayMs: 3 },
+  fast: { maxStepsPerBatch: 320, maxBytesPerBatch: 1100, keyDelayMs: 2 },
+} satisfies Record<string, PasteProfile>;
+
+export type PasteProfileName = keyof typeof PASTE_PROFILES;
+```
+
+### Steps
+
+- [ ] **Step 1: Replace the entire file contents**
+
+Write this exact content to `ui/src/utils/pasteBatches.ts`:
+
+```typescript
+import { estimateBatchBytes } from "./pasteMacro";
+
+interface PasteProfile {
+  maxStepsPerBatch: number;
+  maxBytesPerBatch: number;
+  keyDelayMs: number;
+}
+
+const HEADROOM_BYTES = 8;
+
+function deriveProfile(
+  maxStepsPerBatch: number,
+  keyDelayMs: number,
+): PasteProfile {
+  return {
+    maxStepsPerBatch,
+    maxBytesPerBatch: estimateBatchBytes(maxStepsPerBatch) + HEADROOM_BYTES,
+    keyDelayMs,
+  };
+}
+
+function assertProfilesReachable(
+  profiles: Record<string, PasteProfile>,
+): void {
+  for (const [name, p] of Object.entries(profiles)) {
+    const bytesAtCap = estimateBatchBytes(p.maxStepsPerBatch);
+    if (bytesAtCap > p.maxBytesPerBatch) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: step cap unreachable ` +
+          `(${p.maxStepsPerBatch} steps = ${bytesAtCap} bytes, ` +
+          `byte cap = ${p.maxBytesPerBatch} bytes)`,
+      );
+    }
+  }
+}
+
+export const PASTE_PROFILES = {
+  reliable: deriveProfile(128, 3),
+  fast: deriveProfile(256, 2),
+} satisfies Record<string, PasteProfile>;
+
+assertProfilesReachable(PASTE_PROFILES);
+
+export type PasteProfileName = keyof typeof PASTE_PROFILES;
+```
+
+Key points the implementer must preserve verbatim:
+- Import path `./pasteMacro` (relative, no extension) — matches existing module pattern in `ui/src/utils/`
+- `HEADROOM_BYTES = 8` — do not change this number without updating the spec
+- `deriveProfile(128, 3)` for reliable, `deriveProfile(256, 2)` for fast — exact values from spec §4.2
+- `assertProfilesReachable(PASTE_PROFILES)` is a top-level call, placed AFTER the `PASTE_PROFILES` export and BEFORE the `PasteProfileName` type export — this order is load-bearing: the assertion must run at module evaluation time, and the type export must come last so it can still reference `PASTE_PROFILES`
+- Error message format is exact — preserved so future debuggers can grep for it
+- No other files are touched — if the implementer touches `pasteMacro.ts`, `useKeyboard.ts`, or `PasteModal.tsx`, reject the change
+
+- [ ] **Step 2: Run `tsc --noEmit` to verify the rewrite type-checks**
+
+Run: `cd ui && npx tsc --noEmit`
+
+Expected: exit code 0, no output. The `PasteProfile` interface is unchanged in shape, so all three consumer sites (`PasteModal.tsx:118,129-130`, `useKeyboard.ts:111-112,645-658`, `pasteMacro.ts:114-117`) continue to type-check without modification.
+
+If `tsc` reports an error in `pasteBatches.ts`: re-check the import path and the field names in `deriveProfile`'s return value.
+
+If `tsc` reports an error in any OTHER file: STOP. The scope was violated — a consumer shape assumption has been broken. Revert and report the consumer path, field name, and error.
+
+- [ ] **Step 3: Run ESLint on the frontend tree**
+
+Run: `cd ui && npx eslint './src/**/*.{ts,tsx}'`
+
+Expected: any new errors originating from `pasteBatches.ts` are blocking.
+
+**Known pre-existing noise (non-blocking, per CLAUDE.md):**
+- 600+ `prettier/prettier` CRLF errors on Windows from `core.autocrlf=true` (working-copy artifact; committed blobs are LF)
+- Pre-existing drift in `Button.tsx`, `PasteModal.tsx`, `pasteMacro.ts`, `stores.ts` on main since 2026-03-15 — not caused by this phase
+
+If eslint reports any error whose file path contains `pasteBatches.ts` that is NOT a prettier CRLF error, FIX IT before proceeding. Real lint errors in our file are blocking.
+
+To confirm a `pasteBatches.ts` prettier error is a CRLF artifact (not a real issue):
+```bash
+git cat-file -p HEAD:ui/src/utils/pasteBatches.ts | tr -d -c '\r' | wc -c
+```
+Expected output: `0`. If `0`, the committed blob is LF — the local error is a working-copy artifact and can be ignored.
+
+- [ ] **Step 4: Go side sanity check**
+
+Run: `go vet ./...`
+
+Expected: exit code 0, same result as pre-patch. This phase touches zero Go files; any new `go vet` finding is unrelated and not blocking.
+
+Skip `go build ./...` unless `make build_native` has already run locally; buildkit-based CI is the authoritative Go gate per CLAUDE.md. Phase 3a is frontend-only so this is a sanity smoke test, not a merge gate.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add ui/src/utils/pasteBatches.ts
+git commit -m "$(cat <<'EOF'
+fix(paste): derive profile byte caps from step counts (#40)
+
+Replace hardcoded maxBytesPerBatch magic numbers with deriveProfile()
+that computes the byte ceiling from estimateBatchBytes(steps) plus
+HEADROOM_BYTES. Profile values retune to reliable=128 / fast=256
+steps/batch now that Phase 2 (#38) has landed, restoring the intended
+fast > reliable speed gap.
+
+Add assertProfilesReachable() as a module-load guard that throws if
+any profile ships with an unreachable step cap, catching future
+regressions before any paste can execute.
+
+No changes to estimateBatchBytes, no changes to consumers
+(PasteModal.tsx, useKeyboard.ts, pasteMacro.ts) — the PasteProfile
+interface shape is preserved.
+
+Closes #40
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Verify the commit landed: `git log --oneline -1`. Expected first line matches `fix(paste): derive profile byte caps from step counts (#40)`.
+
+### Rollback condition
+
+If any of Steps 2–4 fail with an error in a forbidden file (anything other than `pasteBatches.ts`), revert uncommitted changes with `git restore ui/src/utils/pasteBatches.ts` and STOP. Report the exact error to the orchestrator — the scope has been violated and the implementation must be re-examined.
+
+If Step 2 (`tsc --noEmit`) fails IN `pasteBatches.ts`, re-read the file, confirm the import path and field names against this plan's Step 1 code block verbatim, and retry.
+
+---
+
+## Verification summary (runs after Task 1 in Step 6 of the orchestrator workflow)
+
+The orchestrator runs these commands independently from the implementation teammate, as a verification gate:
+
+```bash
+cd ui && npx tsc --noEmit && npx eslint './src/**/*.{ts,tsx}'
+cd .. && go build ./... && go vet ./...
+```
+
+- **`tsc --noEmit`**: must pass with zero errors
+- **`eslint`**: pre-existing CRLF noise and pre-existing drift (Button.tsx, PasteModal.tsx, pasteMacro.ts, stores.ts) are known and acceptable; any new error in `pasteBatches.ts` from this phase is blocking
+- **`go build ./...`**: may require `make build_native` first locally; if it fails on missing C artifacts, defer to the CI `golangci-lint.yml` authoritative gate. This phase touches zero Go files.
+- **`go vet ./...`**: must report nothing new from this phase
+
+Runtime verification (manual, post-merge device check):
+1. Boot the dev server and confirm `pasteBatches.ts` imports without the assertion firing
+2. Paste a 10k-char test string in fast mode; confirm it completes noticeably faster than the same string in reliable mode
+3. Confirm in browser devtools that fast mode produces roughly half the number of batches vs reliable for the same paste size
+
+---
+
+## Out-of-scope work (explicitly forbidden this phase)
+
+Per spec §3:
+- No changes to `estimateBatchBytes` in `pasteMacro.ts` (frozen single source of truth)
+- No changes to `useKeyboard.ts` execution logic
+- No changes to `PasteModal.tsx` (the UI reads the profile object indirectly and gets derived values for free)
+- No `package.json` changes (vitest comes in Phase 5)
+- No new `ui/scripts/` directory or external verification script (superseded by the runtime assertion)
+- No changes to `PASTE_LOW_WATERMARK` / `PASTE_HIGH_WATERMARK` (Phase 2's territory)
+- No changes to the 200ms inter-macro sleep in `jsonrpc.go:1078` (Go side, not this phase)
+- No changes to any Go file
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- Spec §4.2 values (128/256, keyDelay 3/2) — covered in Task 1 Step 1
+- Spec §4.3 `deriveProfile` helper — covered in Task 1 Step 1
+- Spec §4.4 `assertProfilesReachable` — covered in Task 1 Step 1
+- Spec §5 invariants I-1 through I-8 — structurally enforced by the code in Task 1 Step 1 (I-1 via derivation + assertion, I-2 via zero changes to `pasteMacro.ts`, I-3 via unchanged interface shape, I-4 via the 128/256 values inside safe zone, I-5 via top-level assertion ordering, I-6 via unchanged keyDelayMs, I-7 via zero changes to `buildPasteMacroBatches`, I-8 via single-file scope)
+- Spec §6 Race A (module-load ordering) — structurally safe because `pasteMacro.ts` has no import from `pasteBatches.ts`
+- Spec §7 acceptance criteria — all four satisfied by the single rewrite in Task 1
+- Spec §8 verification commands — reproduced in the verification summary above
+- Spec §9 rollback — Task 1 rollback condition covers it
+
+**Placeholder scan:** no TBD, no TODO, no "implement later", no "add appropriate error handling", no aspirational test code, no cross-task "similar to Task N" references. Every code block is verbatim final content.
+
+**Type consistency:** `PasteProfile` interface fields `maxStepsPerBatch: number`, `maxBytesPerBatch: number`, `keyDelayMs: number` — consistent between the interface definition, the return type of `deriveProfile`, the parameter type of `assertProfilesReachable`, and the three existing consumer sites (verified by the researcher in Section 3 of the research report).
+
+**Scope check:** single file, single task, well within a single implementation plan.

--- a/docs/superpowers/plans/2026-04-11-paste-profile-derived-constants.md
+++ b/docs/superpowers/plans/2026-04-11-paste-profile-derived-constants.md
@@ -71,6 +71,24 @@ function assertProfilesReachable(
   profiles: Record<string, PasteProfile>,
 ): void {
   for (const [name, p] of Object.entries(profiles)) {
+    if (!Number.isFinite(p.maxStepsPerBatch) || p.maxStepsPerBatch <= 0) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: maxStepsPerBatch must be a positive finite number ` +
+          `(got ${p.maxStepsPerBatch})`,
+      );
+    }
+    if (!Number.isFinite(p.maxBytesPerBatch) || p.maxBytesPerBatch <= 0) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: maxBytesPerBatch must be a positive finite number ` +
+          `(got ${p.maxBytesPerBatch})`,
+      );
+    }
+    if (!Number.isFinite(p.keyDelayMs)) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: keyDelayMs must be a finite number ` +
+          `(got ${p.keyDelayMs})`,
+      );
+    }
     const bytesAtCap = estimateBatchBytes(p.maxStepsPerBatch);
     if (bytesAtCap > p.maxBytesPerBatch) {
       throw new Error(

--- a/docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md
+++ b/docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md
@@ -45,9 +45,9 @@ Restore `fast > reliable` steps-per-batch as a user-visible speed gap, and lock 
 
 ## 4. Design
 
-### 4.1 Approach — Option B (retune larger on consolidated batching)
+### 4.1 Approach — issue Option A, retuned upward after #38
 
-The issue proposed `reliable=96` / `fast=160` conservatively and noted "start conservative and tune after #38 lands. Chunk-aware sender in #38 will make larger batches safer." #38 has landed (PR #52). Tune upward now while still staying well inside the WebRTC SCTP safe zone.
+This phase keeps the issue's "step count is the source of truth" derivation (issue #40 Option A). Only the target step counts are increased from the conservative 96/160 sample in the issue body to 128/256, now that Phase 2 (#38, PR #52) has landed the chunk-aware sender that absorbs host-side backlog at chunk boundaries. The issue explicitly noted "start conservative and tune after #38 lands. Chunk-aware sender in #38 will make larger batches safer." The derivation mechanism (`deriveProfile(steps, keyDelayMs)` → `estimateBatchBytes(steps) + HEADROOM_BYTES`) is unchanged from Option A.
 
 ### 4.2 Values
 
@@ -138,7 +138,7 @@ export type PasteProfileName = keyof typeof PASTE_PROFILES;
 
 The assertion runs once at module-load time in the browser. If a future commit ships a profile whose byte cap is smaller than `estimateBatchBytes(maxStepsPerBatch)` — for example, a manual regression that bypasses `deriveProfile` — the UI fails fast with a clear diagnostic. The assertion is cheap (two multiplications per profile) and runs before any paste can execute, so there is no risk of a partial paste under a misconfigured profile.
 
-The assertion also serves as the acceptance-criterion "unit test or CI script catches unreachable step caps" without requiring `package.json` changes (forbidden this phase) or a new `ui/scripts/` directory.
+The assertion provides fail-fast runtime coverage toward AC3, but the literal "unit test or CI script" portion of the acceptance criterion remains deferred to Phase 5 (vitest harness, issue #45) as described in §7 — `tsc --noEmit` and `eslint` do not execute module code, so CI does not exercise the assertion.
 
 ### 4.5 Why `PasteProfile` shape is preserved
 
@@ -194,7 +194,7 @@ Phase 3a is pure static config. There is one narrow ordering consideration and n
 
 **Trigger:** a consumer file (e.g., `PasteModal.tsx`) imports from `pasteBatches.ts`, which in turn imports `estimateBatchBytes` from `./pasteMacro`.
 
-**Analysis:** ES module graphs are resolved and top-level bodies are executed in dependency order. `pasteMacro.ts` has no import from `pasteBatches.ts`, so there is no cycle. `estimateBatchBytes` is defined at `pasteMacro.ts:36-42` and is exported as a named function declaration, which is fully initialized before any importer's top-level code runs. `deriveProfile` can safely call `estimateBatchBytes` at the top level of `pasteBatches.ts`. `assertProfilesReachable` runs after `PASTE_PROFILES` is constructed, also at the top level, and throws synchronously if the invariant is violated.
+**Analysis:** ES module graphs are resolved and top-level bodies are executed in dependency order. `pasteMacro.ts` has no runtime import from `pasteBatches.ts`, so there is no cycle. The only symbol `pasteMacro.ts` pulls from `useKeyboard.ts` is `MacroStep`, and it is imported via `import type { MacroStep } from "@/hooks/useKeyboard"` (see `pasteMacro.ts:1`). TypeScript's `import type` syntax is erased from emitted JavaScript, so it does NOT create a runtime edge from `pasteMacro.ts` back into `useKeyboard.ts` — and therefore no runtime cycle through `pasteBatches.ts → pasteMacro.ts → useKeyboard.ts → pasteBatches.ts`. `estimateBatchBytes` is defined at `pasteMacro.ts:36-42` and is exported as a named function declaration, which is fully initialized before any importer's top-level code runs. `deriveProfile` can safely call `estimateBatchBytes` at the top level of `pasteBatches.ts`. `assertProfilesReachable` runs after `PASTE_PROFILES` is constructed, also at the top level, and throws synchronously if the invariant is violated.
 
 **Outcome:** no race. Module loading is deterministic and synchronous at the top level.
 

--- a/docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md
+++ b/docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md
@@ -97,6 +97,24 @@ function assertProfilesReachable(
   profiles: Record<string, PasteProfile>,
 ): void {
   for (const [name, p] of Object.entries(profiles)) {
+    if (!Number.isFinite(p.maxStepsPerBatch) || p.maxStepsPerBatch <= 0) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: maxStepsPerBatch must be a positive finite number ` +
+        `(got ${p.maxStepsPerBatch})`,
+      );
+    }
+    if (!Number.isFinite(p.maxBytesPerBatch) || p.maxBytesPerBatch <= 0) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: maxBytesPerBatch must be a positive finite number ` +
+        `(got ${p.maxBytesPerBatch})`,
+      );
+    }
+    if (!Number.isFinite(p.keyDelayMs)) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: keyDelayMs must be a finite number ` +
+        `(got ${p.keyDelayMs})`,
+      );
+    }
     const bytesAtCap = estimateBatchBytes(p.maxStepsPerBatch);
     if (bytesAtCap > p.maxBytesPerBatch) {
       throw new Error(
@@ -162,7 +180,7 @@ The derived wire-byte counts (2310 for reliable, 4614 for fast) are under 30% of
 
 ### Invariant I-7 — no change to batch-flush logic in `buildPasteMacroBatches`
 
-`pasteMacro.ts:156` still flushes on `projectedStepCount > maxStepsPerBatch || projectedBytes > maxBytesPerBatch`. With the derived byte cap, the second clause becomes structurally unreachable in steady state, which simplifies reasoning but does not change the code. The OR clause is retained as defense-in-depth.
+`pasteMacro.ts:156` still flushes on `projectedStepCount > maxStepsPerBatch || projectedBytes > maxBytesPerBatch`. With the derived byte cap, the byte clause is no longer independently binding at or below `maxStepsPerBatch`; it may still fire in the same iteration as the step clause when a projected batch would overflow the declared step cap (because `estimateBatchBytes(maxStepsPerBatch + 1) > maxBytesPerBatch` when `HEADROOM_BYTES < 18`). The OR clause is retained as defense-in-depth and as a safety net if `estimateBatchBytes` ever grows a variable per-step contribution.
 
 ### Invariant I-8 — Phase 1 paste-depth and Phase 2 chunk-aware invariants remain intact
 
@@ -194,7 +212,7 @@ Maps directly to the issue body:
 
 - [ ] **`fast` produces measurably more steps per batch than `reliable` in a 10k-char test** — satisfied by `fast.maxStepsPerBatch=256` vs `reliable.maxStepsPerBatch=128`. Verified numerically: with a 10k-char paste, reliable produces ~79 batches (10000 / 128 rounded up) and fast produces ~40 batches (10000 / 256 rounded up).
 - [ ] **Profile definitions use derived byte limits (not hardcoded magic numbers)** — satisfied by `deriveProfile(steps, keyDelayMs)` helper which computes `maxBytesPerBatch` from `estimateBatchBytes(steps) + HEADROOM_BYTES`.
-- [ ] **Unit test or CI script catches unreachable step caps** — satisfied by `assertProfilesReachable`, a runtime assertion that fires at module load in both dev and production builds. Alternative per the issue ("one-shot verification script in `ui/scripts/`") is explicitly rejected in favor of the runtime assertion, which catches regressions earlier and does not require `package.json` changes.
+- [ ] **Unit test or CI script catches unreachable step caps** — **partially satisfied.** `assertProfilesReachable` provides runtime fail-fast protection at module load (dev server boot, production bundle evaluation, HMR reload) and rejects non-finite, non-positive, or unreachable profile configs. However, it does **not** satisfy issue #40's literal "unit test or CI script" requirement because Phase 3a's verification path (`tsc --noEmit` + `eslint`) does not execute module code, so the assertion is not invoked during CI. Automated CI regression coverage is deferred to Phase 5 (vitest harness, issue #45), which will add a unit test that imports `PASTE_PROFILES` and exercises the assertion. Phase 3a therefore fixes the profile math and adds fail-fast runtime coverage; the "automated CI gate" portion of AC3 is explicitly deferred.
 - [ ] **No wire-format size exceeds known WebRTC SCTP safe limits in either profile** — satisfied by the 14 % / 28 % share of the 16 KiB cross-browser floor documented in Section 4.2.
 
 ## 8. Verification commands
@@ -217,11 +235,11 @@ go build ./... && go vet ./...
 
 Expected: unchanged from pre-patch (this phase touches zero Go files).
 
-Runtime verification:
+Runtime verification (reproducibility note: the `PasteModal` delay path reads `debugMode ? delay : profile.keyDelayMs`, so meaningful timing comparisons require debug mode OFF; the batch-count math below also assumes a one-wire-step-per-character corpus, which is true for plain ASCII but NOT for decomposed Unicode or dead keys that may expand into multiple MacroSteps):
 
-1. Boot the dev server (`cd ui && npm run dev`) and confirm `pasteBatches.ts` imports without the assertion firing
-2. Paste a 10k-char test string in fast mode and confirm it completes faster than the same string in reliable mode
-3. Verify in browser devtools that fast mode produces roughly half the number of `buildPasteMacroBatches`-emitted batches vs reliable for the same paste size
+1. Boot the dev server (`cd ui && npm run dev`) and confirm `pasteBatches.ts` imports without `assertProfilesReachable` firing
+2. With **debug mode OFF**, paste a corpus of 10,000 ASCII `a` characters. Confirm fast completes sooner than reliable on the same corpus.
+3. In browser devtools, confirm the batch counts emitted by `buildPasteMacroBatches`: reliable should produce ~79 batches (10000 / 128 rounded up) and fast should produce ~40 batches (10000 / 256 rounded up). The fast batch count must be strictly smaller than the reliable batch count.
 
 ## 9. Rollback
 

--- a/docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md
+++ b/docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md
@@ -1,0 +1,251 @@
+# Phase 3a Design — Derived-Constant Paste Profiles
+
+**Date:** 2026-04-11
+**Phase:** 3a of the paste-reliability rollout
+**Primary issue:** #40 — "bug: Fast-mode batch byte limit is ineffective (1100 vs 2886 actual)"
+**Branch:** `fix/paste-profile-derived-constants`
+**Scope:** frontend-only, `ui/` subdirectory
+**Touch list (STRICT):** `ui/src/utils/pasteBatches.ts` only
+**Forbidden files:** `ui/src/utils/pasteMacro.ts` (frozen `estimateBatchBytes` — import only), `ui/src/hooks/useKeyboard.ts` (execution logic), `ui/src/components/popovers/PasteModal.tsx` (no user-facing change), `package.json`, all Go sources
+
+## 1. Problem
+
+After PR #47 fixed the wire-byte formula to `6 + stepCount * 18` (press+reset expansion in `executeMacroRemote` at `useKeyboard.ts:321-322`), the current profile values in `pasteBatches.ts` are:
+
+```typescript
+reliable: { maxStepsPerBatch: 128, maxBytesPerBatch: 1200, keyDelayMs: 3 }
+fast:     { maxStepsPerBatch: 320, maxBytesPerBatch: 1100, keyDelayMs: 2 }
+```
+
+Against the corrected formula:
+
+- **reliable** byte cap `(1200 − 6) / 18 = 66.33` → **66 steps** before the byte limit wins. The declared `128` step cap is **unreachable**.
+- **fast** byte cap `(1100 − 6) / 18 = 60.78` → **60 steps** before the byte limit wins. The declared `320` step cap is **unreachable**.
+
+Result: `fast` packs *fewer* steps per batch (60) than `reliable` (66). Combined with the 200 ms inter-macro drain delay in `drainMacroQueue` (`jsonrpc.go:1078`, untouched in this phase), more batches → more drains → more total paste latency. **`fast` mode is measurably slower than `reliable` mode**, which is the opposite of the intended UX. This was verified against the current tree in the Step 2 research report — all numbers reproduce exactly.
+
+Phase 2 (PR #52, closing #38) added a chunk-aware large-paste layer but intentionally left `PASTE_PROFILES` untouched so Phase 3a would have a clean slate.
+
+## 2. Goal
+
+Replace the hardcoded magic-number byte caps with a single derivation path: declare the intended step count per profile, derive the byte ceiling from `estimateBatchBytes(steps) + HEADROOM_BYTES`, and fail fast at module load if any profile ships with an unreachable step cap.
+
+Restore `fast > reliable` steps-per-batch as a user-visible speed gap, and lock in the invariant that the step cap is always the binding constraint.
+
+## 3. Non-goals (explicit out-of-scope)
+
+- Changing `estimateBatchBytes` — it is the single source of truth (CLAUDE.md). This phase imports it, does not modify it.
+- Changing `useKeyboard.ts` or any execution logic — Phase 3a is config-only.
+- Changing `PasteModal.tsx` — no user-facing surface change.
+- Changing the 200 ms inter-macro sleep in `drainMacroQueue` — Go side, not this phase.
+- Adding vitest — `package.json` is forbidden in Phase 3a per the rollout plan; adding it is Phase 5's scope.
+- Creating a new `ui/scripts/` directory for an out-of-process verification script — superseded by the runtime assertion.
+- Retuning `PASTE_LOW_WATERMARK` / `PASTE_HIGH_WATERMARK` — Phase 2's territory.
+- Any change to Go sources.
+
+## 4. Design
+
+### 4.1 Approach — Option B (retune larger on consolidated batching)
+
+The issue proposed `reliable=96` / `fast=160` conservatively and noted "start conservative and tune after #38 lands. Chunk-aware sender in #38 will make larger batches safer." #38 has landed (PR #52). Tune upward now while still staying well inside the WebRTC SCTP safe zone.
+
+### 4.2 Values
+
+| Profile  | `maxStepsPerBatch` | `keyDelayMs` | Derived wire bytes (`6 + steps*18`) | Share of 16 KiB safe zone |
+|----------|--------------------|--------------|-------------------------------------|---------------------------|
+| reliable | 128                | 3            | 2310                                | 14 %                      |
+| fast     | 256                | 2            | 4614                                | 28 %                      |
+
+Both comfortably under the 16 KiB cross-browser WebRTC data-channel fragmentation threshold documented in the researcher's Section 5 (sources: lgrahl.de, Mozilla WebRTC blog, RFC 8831, Pion docs). Chrome, Firefox, Safari, and Pion all handle messages well past 16 KiB, but 16 KiB is the practical cross-browser floor.
+
+`keyDelayMs` values are preserved — reliable stays at 3 ms for host catch-up headroom, fast stays at 2 ms for throughput. No rationale to move them in this phase.
+
+### 4.3 Derivation helper
+
+```typescript
+import { estimateBatchBytes } from "./pasteMacro";
+
+interface PasteProfile {
+  maxStepsPerBatch: number;
+  maxBytesPerBatch: number;
+  keyDelayMs: number;
+}
+
+// Headroom above the exact byte count for the declared step cap.
+// Keeps the step cap as the binding constraint at batch-flush time
+// even if future rounding or alignment adds a few bytes.
+const HEADROOM_BYTES = 8;
+
+function deriveProfile(
+  maxStepsPerBatch: number,
+  keyDelayMs: number,
+): PasteProfile {
+  return {
+    maxStepsPerBatch,
+    maxBytesPerBatch: estimateBatchBytes(maxStepsPerBatch) + HEADROOM_BYTES,
+    keyDelayMs,
+  };
+}
+```
+
+`estimateBatchBytes` is already exported from `pasteMacro.ts:36` — no changes needed on the `pasteMacro` side.
+
+### 4.4 Runtime assertion
+
+```typescript
+function assertProfilesReachable(
+  profiles: Record<string, PasteProfile>,
+): void {
+  for (const [name, p] of Object.entries(profiles)) {
+    const bytesAtCap = estimateBatchBytes(p.maxStepsPerBatch);
+    if (bytesAtCap > p.maxBytesPerBatch) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: step cap unreachable ` +
+        `(${p.maxStepsPerBatch} steps = ${bytesAtCap} bytes, ` +
+        `byte cap = ${p.maxBytesPerBatch} bytes)`,
+      );
+    }
+  }
+}
+
+export const PASTE_PROFILES = {
+  reliable: deriveProfile(128, 3),
+  fast:     deriveProfile(256, 2),
+} satisfies Record<string, PasteProfile>;
+
+assertProfilesReachable(PASTE_PROFILES);
+
+export type PasteProfileName = keyof typeof PASTE_PROFILES;
+```
+
+The assertion runs once at module-load time in the browser. If a future commit ships a profile whose byte cap is smaller than `estimateBatchBytes(maxStepsPerBatch)` — for example, a manual regression that bypasses `deriveProfile` — the UI fails fast with a clear diagnostic. The assertion is cheap (two multiplications per profile) and runs before any paste can execute, so there is no risk of a partial paste under a misconfigured profile.
+
+The assertion also serves as the acceptance-criterion "unit test or CI script catches unreachable step caps" without requiring `package.json` changes (forbidden this phase) or a new `ui/scripts/` directory.
+
+### 4.5 Why `PasteProfile` shape is preserved
+
+Consumers read `maxStepsPerBatch` and `maxBytesPerBatch` as independent numeric fields. The derivation happens at construction time, and the resulting object is structurally identical to the current shape. No consumer changes are required.
+
+Verified consumers (from researcher Section 3):
+
+- `PasteModal.tsx:50` — `useState<PasteProfileName>("reliable")`, reads via `PASTE_PROFILES[pasteProfile]` at line 118, destructures both fields at lines 129–130
+- `useKeyboard.ts:111-112` (interface shape), `:645-658` (forwards both fields to `buildPasteMacroBatches`)
+- `pasteMacro.ts:114-117` (consumes both fields in the flush condition at line 156)
+
+## 5. Correctness invariants
+
+This section is the load-bearing part of the spec for the Oracle cross-review.
+
+### Invariant I-1 — step cap is the binding constraint
+
+For every profile `p` in `PASTE_PROFILES`, `estimateBatchBytes(p.maxStepsPerBatch) <= p.maxBytesPerBatch`. Enforced structurally by `deriveProfile` (byte cap is computed from the step cap plus positive headroom) and verified at module load by `assertProfilesReachable`. If both are present and the assertion passes, `buildPasteMacroBatches` will always flush on the step cap, not the byte cap, when a batch reaches the declared size.
+
+### Invariant I-2 — `estimateBatchBytes` remains the single source of wire-byte truth
+
+The formula `6 + stepCount * 18` is owned by `pasteMacro.ts:36-42` and is NOT modified in this phase. `pasteBatches.ts` consumes it through a normal TypeScript import. Any future change to the wire format must update `estimateBatchBytes` once; the profiles self-correct.
+
+### Invariant I-3 — `PasteProfile` interface shape is preserved
+
+Fields: `maxStepsPerBatch`, `maxBytesPerBatch`, `keyDelayMs`. Types: `number`. All three consumers (Section 4.5) continue to read the same field names with the same types. Zero changes at consumer sites.
+
+### Invariant I-4 — both profiles remain well inside the WebRTC SCTP cross-browser safe zone
+
+The derived wire-byte counts (2310 for reliable, 4614 for fast) are under 30% of the 16 KiB cross-browser message-size floor. No host-side fragmentation or reassembly concerns. No risk of Chromium closing the data channel for oversized messages (hard limit is 256 KiB per the Pion docs).
+
+### Invariant I-5 — load-time assertion fires before any paste can execute
+
+`assertProfilesReachable(PASTE_PROFILES)` is called at the top level of `pasteBatches.ts` after the `PASTE_PROFILES` export, before the `PasteProfileName` type export. ES module evaluation is synchronous at top level; any consumer that imports from `pasteBatches.ts` will trigger the assertion before its own code runs. If the assertion throws, the import itself fails, which surfaces in the dev-server boot and in production as a fatal module-load error. No paste can run with a misconfigured profile.
+
+### Invariant I-6 — `keyDelayMs` values and semantic meaning preserved
+
+`reliable.keyDelayMs = 3`, `fast.keyDelayMs = 2`. These values already ship on main and are passed through `buildPasteMacroBatches` into the per-step macro construction. This phase does not touch them.
+
+### Invariant I-7 — no change to batch-flush logic in `buildPasteMacroBatches`
+
+`pasteMacro.ts:156` still flushes on `projectedStepCount > maxStepsPerBatch || projectedBytes > maxBytesPerBatch`. With the derived byte cap, the second clause becomes structurally unreachable in steady state, which simplifies reasoning but does not change the code. The OR clause is retained as defense-in-depth.
+
+### Invariant I-8 — Phase 1 paste-depth and Phase 2 chunk-aware invariants remain intact
+
+No changes to `pasteDepth` atomic counter logic, `queuedMacro.session` wiring, `waitForPasteDrain` helper, or `partitionBatchesByChunkChars`. This phase changes only the profile-construction path in one file.
+
+## 6. Race walkthrough
+
+Phase 3a is pure static config. There is one narrow ordering consideration and no new concurrency:
+
+### Race A — module-load ordering
+
+**Trigger:** a consumer file (e.g., `PasteModal.tsx`) imports from `pasteBatches.ts`, which in turn imports `estimateBatchBytes` from `./pasteMacro`.
+
+**Analysis:** ES module graphs are resolved and top-level bodies are executed in dependency order. `pasteMacro.ts` has no import from `pasteBatches.ts`, so there is no cycle. `estimateBatchBytes` is defined at `pasteMacro.ts:36-42` and is exported as a named function declaration, which is fully initialized before any importer's top-level code runs. `deriveProfile` can safely call `estimateBatchBytes` at the top level of `pasteBatches.ts`. `assertProfilesReachable` runs after `PASTE_PROFILES` is constructed, also at the top level, and throws synchronously if the invariant is violated.
+
+**Outcome:** no race. Module loading is deterministic and synchronous at the top level.
+
+### Race B — HMR and development reloads
+
+**Trigger:** Vite HMR reloads `pasteBatches.ts` after an edit.
+
+**Analysis:** HMR re-executes the module body, which re-runs `deriveProfile` and `assertProfilesReachable`. If a developer ships a bad profile mid-session, HMR surfaces the error in the browser console immediately rather than letting the old module linger.
+
+**Outcome:** no hazard. HMR is our friend here — it amplifies the guard.
+
+## 7. Acceptance criteria
+
+Maps directly to the issue body:
+
+- [ ] **`fast` produces measurably more steps per batch than `reliable` in a 10k-char test** — satisfied by `fast.maxStepsPerBatch=256` vs `reliable.maxStepsPerBatch=128`. Verified numerically: with a 10k-char paste, reliable produces ~79 batches (10000 / 128 rounded up) and fast produces ~40 batches (10000 / 256 rounded up).
+- [ ] **Profile definitions use derived byte limits (not hardcoded magic numbers)** — satisfied by `deriveProfile(steps, keyDelayMs)` helper which computes `maxBytesPerBatch` from `estimateBatchBytes(steps) + HEADROOM_BYTES`.
+- [ ] **Unit test or CI script catches unreachable step caps** — satisfied by `assertProfilesReachable`, a runtime assertion that fires at module load in both dev and production builds. Alternative per the issue ("one-shot verification script in `ui/scripts/`") is explicitly rejected in favor of the runtime assertion, which catches regressions earlier and does not require `package.json` changes.
+- [ ] **No wire-format size exceeds known WebRTC SCTP safe limits in either profile** — satisfied by the 14 % / 28 % share of the 16 KiB cross-browser floor documented in Section 4.2.
+
+## 8. Verification commands
+
+Per CLAUDE.md's verification rules:
+
+```bash
+cd ui && npx tsc --noEmit && npx eslint './src/**/*.{ts,tsx}'
+```
+
+Expected:
+- `tsc --noEmit` passes with zero errors (both files compile against the existing `PasteProfile` interface)
+- `eslint` may emit pre-existing CRLF noise on Windows (600+ prettier errors from `core.autocrlf=true`, per CLAUDE.md); committed blobs are LF and `golangci-lint` on the Go side is the real merge gate, but this phase is frontend-only so the CI gate is `ui-lint` — known failing on main since 2026-03-15 on unrelated files; any new failures in `pasteBatches.ts` from this PR are blocking
+
+Go side is untouched, but a sanity pass is allowed:
+
+```bash
+go build ./... && go vet ./...
+```
+
+Expected: unchanged from pre-patch (this phase touches zero Go files).
+
+Runtime verification:
+
+1. Boot the dev server (`cd ui && npm run dev`) and confirm `pasteBatches.ts` imports without the assertion firing
+2. Paste a 10k-char test string in fast mode and confirm it completes faster than the same string in reliable mode
+3. Verify in browser devtools that fast mode produces roughly half the number of `buildPasteMacroBatches`-emitted batches vs reliable for the same paste size
+
+## 9. Rollback
+
+Single commit, single file changed. Revert with `git revert <sha>` — profiles return to the existing 128/1200 and 320/1100 values. The inversion bug returns with them, but correctness of the rest of the paste pipeline is unaffected because no consumer or execution path changes.
+
+## 10. Risks and mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Larger fast batches trigger cross-browser fragmentation | Low | Both profiles are ≤ 28 % of the 16 KiB floor; verified against Mozilla, RFC 8831, Pion, lgrahl.de sources in Section 5 of research report |
+| Derived byte cap accidentally becomes smaller than `estimateBatchBytes(steps)` | Blocked | `deriveProfile` structurally prevents this; `assertProfilesReachable` is a defense-in-depth belt-and-braces check |
+| Host USB HID input queue saturates at 256 steps per batch | Low | `keyDelayMs=2` (unchanged) and the 200 ms inter-macro drain in `drainMacroQueue` (unchanged) both absorb host backlog; Phase 2's chunk-aware sender also absorbs backlog at chunk boundaries |
+| Runtime assertion fires in production on a bad refactor | Intended | That is the feature — fail fast at module load rather than silently shipping an inverted profile |
+| `estimateBatchBytes` formula changes in a future phase | Low | Both profiles self-correct because the byte cap is derived from it at module load |
+| Phase 4 or 5 touches `pasteBatches.ts` unknowingly | Low | Forbidden list in this spec + phase touch-list enforcement in the orchestrator workflow |
+
+## 11. Dependencies
+
+- Phase 1 (#49) merged — provides the paste-depth semantics and shallow queue this phase runs on top of
+- Phase 2 (#52, closing #38) merged — provides the chunk-aware sender and large-paste safe mode this phase retunes against
+- `estimateBatchBytes` exported from `pasteMacro.ts:36` (already exported on main)
+
+No new dependencies.
+
+## 12. Open questions
+
+None. This is a single-file config change with a well-defined math fix and a runtime guard. The brainstorm settled all design questions; the research report confirmed all consumer wiring.

--- a/ui/src/utils/pasteBatches.ts
+++ b/ui/src/utils/pasteBatches.ts
@@ -1,12 +1,56 @@
+import { estimateBatchBytes } from "./pasteMacro";
+
 interface PasteProfile {
   maxStepsPerBatch: number;
   maxBytesPerBatch: number;
   keyDelayMs: number;
 }
 
+const HEADROOM_BYTES = 8;
+
+function deriveProfile(maxStepsPerBatch: number, keyDelayMs: number): PasteProfile {
+  return {
+    maxStepsPerBatch,
+    maxBytesPerBatch: estimateBatchBytes(maxStepsPerBatch) + HEADROOM_BYTES,
+    keyDelayMs,
+  };
+}
+
+function assertProfilesReachable(profiles: Record<string, PasteProfile>): void {
+  for (const [name, p] of Object.entries(profiles)) {
+    if (!Number.isFinite(p.maxStepsPerBatch) || p.maxStepsPerBatch <= 0) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: maxStepsPerBatch must be a positive finite number ` +
+          `(got ${p.maxStepsPerBatch})`,
+      );
+    }
+    if (!Number.isFinite(p.maxBytesPerBatch) || p.maxBytesPerBatch <= 0) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: maxBytesPerBatch must be a positive finite number ` +
+          `(got ${p.maxBytesPerBatch})`,
+      );
+    }
+    if (!Number.isFinite(p.keyDelayMs)) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: keyDelayMs must be a finite number ` + `(got ${p.keyDelayMs})`,
+      );
+    }
+    const bytesAtCap = estimateBatchBytes(p.maxStepsPerBatch);
+    if (bytesAtCap > p.maxBytesPerBatch) {
+      throw new Error(
+        `PASTE_PROFILES["${name}"]: step cap unreachable ` +
+          `(${p.maxStepsPerBatch} steps = ${bytesAtCap} bytes, ` +
+          `byte cap = ${p.maxBytesPerBatch} bytes)`,
+      );
+    }
+  }
+}
+
 export const PASTE_PROFILES = {
-  reliable: { maxStepsPerBatch: 128, maxBytesPerBatch: 1200, keyDelayMs: 3 },
-  fast: { maxStepsPerBatch: 320, maxBytesPerBatch: 1100, keyDelayMs: 2 },
+  reliable: deriveProfile(128, 3),
+  fast: deriveProfile(256, 2),
 } satisfies Record<string, PasteProfile>;
+
+assertProfilesReachable(PASTE_PROFILES);
 
 export type PasteProfileName = keyof typeof PASTE_PROFILES;


### PR DESCRIPTION
## Summary

- Replace hardcoded `maxBytesPerBatch` magic numbers in `ui/src/utils/pasteBatches.ts` with a `deriveProfile(steps, keyDelayMs)` helper that computes the byte cap from `estimateBatchBytes(steps) + HEADROOM_BYTES`.
- Retune profile values to `reliable = deriveProfile(128, 3)` and `fast = deriveProfile(256, 2)` now that Phase 2 (#38, PR #52) has landed the chunk-aware large-paste sender. This restores the intended `fast > reliable` steps-per-batch gap that was inverted on main.
- Add `assertProfilesReachable()` as a module-load guard that throws on (a) non-finite or non-positive `maxStepsPerBatch` / `maxBytesPerBatch`, (b) non-finite `keyDelayMs`, and (c) an unreachable step cap (`estimateBatchBytes(steps) > byteCap`). Runs synchronously at top level before any paste consumer can load the module.
- Scope is strictly one file — `ui/src/utils/pasteBatches.ts`. `estimateBatchBytes` (the frozen single source of wire-byte truth), `useKeyboard.ts` execution path, `PasteModal.tsx`, `package.json`, and all Go sources are byte-identical to main.

## Closes

Closes #40

## Acceptance criteria (from issue body)

- [x] `fast` produces measurably more steps per batch than `reliable` in a 10k-char test — `fast=256` vs `reliable=128`; ~40 vs ~79 batches for 10000 ASCII chars
- [x] Profile definitions use derived byte limits (not hardcoded magic numbers) — `deriveProfile()` computes the byte cap from `estimateBatchBytes(steps) + 8`
- [x] **Partially satisfied:** unit test or CI script catches unreachable step caps — `assertProfilesReachable` provides fail-fast runtime coverage at module load (dev server boot, production bundle evaluation, HMR reload). The literal "CI-gate" portion of this criterion is deferred to Phase 5 (#45 vitest harness), because Phase 3a's verification path (`tsc --noEmit` + `eslint`) does not execute module code. See spec §7 for the deferral rationale.
- [x] No wire-format size exceeds known WebRTC SCTP safe limits — `reliable = 2318 bytes` (14% of the 16 KiB cross-browser floor), `fast = 4622 bytes` (28%)

## Scope constraints respected

The following files and behaviors were explicitly **not** touched:

- `ui/src/utils/pasteMacro.ts` — `estimateBatchBytes` is the frozen single source of wire-byte truth (CLAUDE.md); imported from, not modified
- `ui/src/hooks/useKeyboard.ts` — execution logic frozen
- `ui/src/components/popovers/PasteModal.tsx` — no user-facing surface change; consumers read `maxStepsPerBatch`/`maxBytesPerBatch` indirectly and get derived values for free
- `package.json` — vitest harness deferred to Phase 5 (#45)
- `PASTE_LOW_WATERMARK` / `PASTE_HIGH_WATERMARK` — Phase 2 territory
- 200 ms inter-macro sleep in `jsonrpc.go:1078` — Go side
- All Go files
- `.github/workflows/*`, `CLAUDE.md`, `DEVELOPMENT.md`, `README.md`

`git show --stat 0ee6fce` confirms only `ui/src/utils/pasteBatches.ts` modified in the implementation commit. `git diff main HEAD -- ui/src/utils/pasteMacro.ts ui/src/hooks/useKeyboard.ts ui/src/components/popovers/PasteModal.tsx` returns empty.

## Test plan

Verification commands actually run:

- [x] `cd ui && npx tsc --noEmit` — PASS (exit 0, no output)
- [x] `cd ui && npx eslint './src/utils/pasteBatches.ts'` — clean
- [x] `cd ui && npx eslint './src/**/*.{ts,tsx}'` — the only errors are pre-existing Windows `core.autocrlf=true` CRLF noise (verified committed blob is LF via `git cat-file -p HEAD:ui/src/utils/pasteBatches.ts | tr -d -c '\r' | wc -c` → 0) plus two pre-existing warnings in unrelated files. Per CLAUDE.md, `ui-lint` CI has been failing on main since 2026-03-15 on pre-existing drift; `golangci-lint` is the real merge gate, and this phase touches zero Go files.
- [ ] Device runtime verification (deferred to merge-time manual check): boot dev server, confirm `pasteBatches.ts` imports without `assertProfilesReachable` firing, paste 10,000 ASCII `a` characters in fast mode with debug mode OFF, confirm fast completes sooner than reliable and produces ~40 batches vs ~79 for reliable.

Go verification deferred to CI — `go` is not on the local PATH and Phase 3a touches zero Go files, so `golangci-lint.yml` is the authoritative merge gate.

## Correctness invariants verified in code

- **I-1** (step cap binding): `estimateBatchBytes(128) = 2310`, cap = 2318 → 2310 ≤ 2318 ✓. `estimateBatchBytes(256) = 4614`, cap = 4622 → 4614 ≤ 4622 ✓.
- **I-2**: `pasteMacro.ts:41` still `return 6 + stepCount * 18`. Zero diff vs main.
- **I-3**: `PasteProfile` interface shape unchanged; all three consumer sites type-check against the new profile without edits.
- **I-4**: Both profiles under 30% of the 16 KiB SCTP cross-browser safe floor.
- **I-5**: `assertProfilesReachable(PASTE_PROFILES)` at pasteBatches.ts:54 — top-level synchronous throw before any consumer can paste.
- **I-6**: `keyDelayMs` values preserved (`reliable=3`, `fast=2`).
- **I-7**: `pasteMacro.ts:156` flush OR clause untouched. Byte clause is no longer independently binding at or below `maxStepsPerBatch` but may co-fire at `maxStepsPerBatch + 1` when `HEADROOM_BYTES < 18`.
- **I-8**: Phase 1 / Phase 2 machinery (pasteDepth atomic, waitForPasteDrain, partitionBatchesByChunkChars, 200 ms inter-macro sleep) byte-identical to main.

## Review status

### Oracle cross-review (Step 4.5) — **APPROVE** after 3 iterations

GPT-5.4 Pro browser-mode spec cross-review against `docs/superpowers/specs/2026-04-11-paste-profile-derived-constants-design.md`. All 7 findings across iter 1–2 fixed and verified in iter 3:

- **Iter 1** (SHA `4f117e0`) → REQUEST CHANGES, 4 findings (P1 AC3 overclaim, P2 I-7 math, P2 assertion completeness, P3 verification recipe)
- **Iter 2** (SHA `d96e828`) → REQUEST CHANGES, 3 findings (P2 §4.4 contradiction, P3 Option A/B label, P3 type-only import documentation)
- **Iter 3** (SHA `f0882a6`) → APPROVE, zero net-new findings, all 7 prior findings verified FIXED

### Codex cross-review (Step 6.5) — **APPROVE** on iter 1

`codex exec review --base main --full-auto --skip-git-repo-check` against commit `0ee6fce`. Verdict: "The functional change in `ui/src/utils/pasteBatches.ts` keeps the profile configuration consistent with the existing wire-size estimator and batching logic, and I did not find a concrete regression introduced by the diff. The updated constants and load-time assertion appear compatible with the current paste execution path." Codex also ran `eslint src/utils/pasteBatches.ts` (clean) and `git diff --check` (clean) during review. Single iteration was sufficient — unusual for this codebase (memory notes phases typically take 4–8 codex-driven fix commits) but consistent with (a) the one-file 48-line surface area, (b) 7 oracle-driven revisions having pre-tightened the design before implementation, (c) the plan containing the exact code to write.

### In-house review (Step 7) — **APPROVE** (synthesized inline)

The dedicated code-reviewer teammate was non-responsive during this phase (3 consecutive idles with zero output), so the synthesis was performed inline by the orchestrator with direct file reads. All 8 correctness invariants independently verified in actual code (not just spec), all 4 assertion branches confirmed present with correct predicates and error messages, scope lock verified via `git show --stat 0ee6fce` and `git diff main HEAD` on forbidden files. No independent findings beyond one P3 non-blocking observation (integer-ness of `maxStepsPerBatch` is not asserted; profile values are hardcoded integers so deferred as a follow-up only if it becomes relevant). Oracle and Codex agreement weighted heavily against the independent read; all three agree the implementation is correct against spec and scope.

## Known limitations

- **AC3 is only partially satisfied** (automated CI gate deferred to Phase 5 vitest harness, #45). Runtime fail-fast coverage is in place via `assertProfilesReachable`, and the static-verification path (`tsc --noEmit` + `eslint`) catches type-level regressions, but no CI step currently executes the module body. See spec §7 for the deferral rationale.
- **No unit test for `deriveProfile` or `assertProfilesReachable`** — blocked by `package.json` being out of scope in Phase 3a. Adding a vitest harness is Phase 5's work.
- **No device-runtime timing measurement in this PR** — the acceptance criterion "fast completes sooner" is structurally satisfied by `fast=256` vs `reliable=128` and the resulting ~40 vs ~79 batch counts against the 200 ms inter-macro drain delay, but no on-device stopwatch measurement was captured. Suggested manual verification at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
