### PR TITLE
chore(paste): rename pasteInterMacroDrainMs to pasteInterMacroDrain

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1014,12 +1014,12 @@ func rpcSetLocalLoopbackOnly(enabled bool) error {
 // See docs/superpowers/specs/2026-04-08-paste-pipeline-flow-control-design.md.
 const macroQueueDepth = 64
 
-// pasteInterMacroDrainMs is the inter-macro pause inside drainMacroQueue that
+// pasteInterMacroDrain is the inter-macro pause inside drainMacroQueue that
 // gives the host USB input queue time to consume pending reports between
 // consecutive macros. PR #41 load-bearing fix — do not retune without a
 // dedicated profiling PR. Phase 2 (#38) adds chunk-boundary pauses on top
 // of this delay, not instead of it.
-const pasteInterMacroDrainMs = 200 * time.Millisecond
+const pasteInterMacroDrain = 200 * time.Millisecond
 
 // queuedMacro wraps a macro batch with its paste flag and origin session so
 // drainMacroQueue and cancelAndDrainMacroQueue can report state messages back
@@ -1142,7 +1142,7 @@ func drainMacroQueue() {
 		// buffered HID reports before the next macro arrives. Without this,
 		// back-to-back macros overflow the host's USB input queue, causing
 		// character corruption on busy systems.
-		time.Sleep(pasteInterMacroDrainMs)
+		time.Sleep(pasteInterMacroDrain)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Rename `pasteInterMacroDrainMs` → `pasteInterMacroDrain` in `jsonrpc.go` (3 occurrences: one comment line, one `const` declaration, one `time.Sleep` call site)
- Value and semantics **unchanged**: still `200 * time.Millisecond`, still the PR #41 load-bearing inter-macro drain pause
- Pure identifier rename with zero behavioral effect

## Why

`staticcheck` ST1011 flags the `Ms` suffix as redundant because the variable is typed `time.Duration` and the unit is already encoded in the type. Phase 2 PR #52 introduced the name and landed while the lint gate was red, leaving every subsequent branch inheriting the failure.

From the CI log on main's most recent run (`24279203468`):

\`\`\`
jsonrpc.go:1022:7: ST1011: var pasteInterMacroDrainMs is of type time.Duration;
  don't use unit-specific suffix \"Ms\" (staticcheck)
\`\`\`

This tiny PR turns the `golangci-lint` merge gate green on `main` so that Phase 3a (PR #54), Phase 3b, Phase 3c, and every downstream phase inherit a green baseline without bundling a scope-breaking Go-side rename into a frontend-only PR.

## Scope

- Only `jsonrpc.go` modified (3 lines)
- No behavior change; `const pasteInterMacroDrain = 200 * time.Millisecond` unchanged in value
- Phase 2 spec and plan docs at `docs/superpowers/{specs,plans}/2026-04-11-large-paste-safe-mode*.md` reference the old name historically and are intentionally NOT touched — they document what Phase 2 actually did at the time

## Test plan

- [x] `git diff main HEAD` shows only `jsonrpc.go` modified, 3 insertions / 3 deletions
- [x] Grep confirms zero remaining references to `pasteInterMacroDrainMs` in `.go` files
- [ ] CI `golangci-lint` gate turns green
- [ ] CI `UI Lint` is pre-existing drift on main (failing since 2026-03-15 per CLAUDE.md) — not affected by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)