### PR TITLE
fix(paste): probe first large paste chunk support

### DIFF
--- a/docs/superpowers/plans/2026-04-24-first-paste-chunk-probe.md
+++ b/docs/superpowers/plans/2026-04-24-first-paste-chunk-probe.md
@@ -1,0 +1,194 @@
+# First-Paste Chunk Probe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix #58 so the first large paste in a fresh modern browser session uses Phase 2 chunk-aware drain boundaries without regressing legacy firmware.
+
+**Architecture:** `executePasteText` will optimistically use chunk mode for large RPC HID pastes unless a session-local negative latch says paste-state support is absent. The first chunk runs a short paste-start probe before the existing required drain. If the probe times out, the paste falls back in-place to the existing non-chunk remainder path and future large pastes in the same JS session skip probing.
+
+**Tech Stack:** TypeScript 5 / React 18, Zustand store, WebRTC data channel for HID RPC.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-first-paste-chunk-probe-design.md`
+
+---
+
+## Scope
+
+**Modify:**
+- `ui/src/hooks/useKeyboard.ts`
+- `docs/superpowers/specs/2026-04-24-first-paste-chunk-probe-design.md`
+- `docs/superpowers/plans/2026-04-24-first-paste-chunk-probe.md`
+
+**Avoid unless a direct conflict appears:**
+- `ui/src/utils/pasteMacro.ts`
+
+**Forbidden:**
+- Go files
+- `package.json`
+- `package-lock.json`
+- `ui/src/components/popovers/PasteModal.tsx`
+
+## Task 1: Add Session Capability State and Probe Helper
+
+**Files:**
+- Modify: `ui/src/hooks/useKeyboard.ts`
+
+- [ ] Add a probe timeout constant near the existing paste drain constants:
+
+```typescript
+const PASTE_STATE_SUPPORT_PROBE_TIMEOUT_MS = 2000;
+```
+
+- [ ] Extend the module-level latch block:
+
+```typescript
+let executePasteTextInFlight = false;
+let pasteStateSupportObserved = false;
+let pasteStateSupportNegativeLatched = false;
+```
+
+- [ ] In the `KeyboardMacroStateMessage` handler, set
+  `pasteStateSupportNegativeLatched = false` whenever a real paste-state event
+  sets `pasteStateSupportObserved = true`.
+
+- [ ] Add `waitForPasteStartProbe(timeoutMs, signal?)` near `waitForPasteDrain`. It must subscribe before sampling, resolve `true` on any `isPasteInProgress=true`, resolve `false` on timeout, and reject with `Error("Paste execution aborted")` on abort.
+
+## Task 2: Loosen Chunk Eligibility
+
+**Files:**
+- Modify: `ui/src/hooks/useKeyboard.ts`
+
+- [ ] Replace the old `pasteStateSupportObserved` chunk gate with:
+
+```typescript
+let chunkMode =
+  rpcHidReady &&
+  !pasteStateSupportNegativeLatched &&
+  text.length >= policy.autoThresholdChars;
+```
+
+- [ ] Make `chunks` and `chunkTotalForProgress` mutable so fallback can switch progress to non-chunk:
+
+```typescript
+let chunks: PasteChunkPlan[] = chunkMode
+  ? partitionBatchesByChunkChars(batchStats, policy.chunkChars)
+  : [{ chunkIndex: 0, batchStartIndex: 0, batchEndIndex: batches.length, sourceChars: text.length }];
+let chunkTotalForProgress = chunkMode ? chunks.length : 0;
+```
+
+## Task 3: Probe After the First Dispatched Batch
+
+**Files:**
+- Modify: `ui/src/hooks/useKeyboard.ts`
+
+- [ ] Add local per-paste state after chunk planning:
+
+```typescript
+let pasteStateSupportProvenForPaste = pasteStateSupportObserved;
+let pasteStartProbeOutcome: Promise<
+  { supported: boolean } | { error: Error }
+> | null = null;
+```
+
+- [ ] In the first chunk's batch loop, arm the probe immediately before dispatching the first paste batch when chunk mode is active and support is not already proven:
+
+```typescript
+if (chunkMode && !pasteStateSupportProvenForPaste && pasteStartProbeOutcome === null) {
+  pasteStartProbeOutcome = waitForPasteStartProbe(
+    PASTE_STATE_SUPPORT_PROBE_TIMEOUT_MS,
+    signal,
+  ).then(
+    supported => ({ supported }),
+    error => ({
+      error: error instanceof Error ? error : new Error(String(error)),
+    }),
+  );
+}
+```
+
+- [ ] After that batch has been sent and progress has been emitted, await the handled probe outcome:
+
+```typescript
+if (pasteStartProbeOutcome !== null && !pasteStateSupportProvenForPaste) {
+  const probeResult = await pasteStartProbeOutcome;
+  pasteStartProbeOutcome = null;
+  if ("error" in probeResult) {
+    throw probeResult.error;
+  }
+  if (probeResult.supported) {
+    pasteStateSupportProvenForPaste = true;
+  } else {
+    if (!pasteStateSupportObserved) {
+      pasteStateSupportNegativeLatched = true;
+    }
+    chunkMode = false;
+    chunkTotalForProgress = 0;
+    const remainingBatchStartIndex = b + 1;
+    if (remainingBatchStartIndex < batches.length) {
+      let remainingSourceChars = 0;
+      for (let rb = remainingBatchStartIndex; rb < batches.length; rb++) {
+        remainingSourceChars += batchStats[rb].sourceChars;
+      }
+      chunks = [
+        {
+          chunkIndex: 0,
+          batchStartIndex: remainingBatchStartIndex,
+          batchEndIndex: batches.length,
+          sourceChars: remainingSourceChars,
+        },
+      ];
+    } else {
+      chunks = [];
+    }
+    ci = -1;
+    break;
+  }
+}
+```
+
+- [ ] Gate chunk-boundary required drains on both `chunkMode` and `pasteStateSupportProvenForPaste` so legacy firmware never reaches a long required timeout.
+
+- [ ] Ensure fallback starts from `b + 1`, not batch zero, so text is not duplicated and the remainder is not skipped.
+
+- [ ] Reset the loop index to `-1` before breaking so the `for` loop increment moves to the remaining non-chunk segment at index zero.
+
+## Task 4: Preserve Existing Drain and Abort Behavior
+
+**Files:**
+- Modify: `ui/src/hooks/useKeyboard.ts`
+
+- [ ] Leave `PASTE_LOW_WATERMARK` and `PASTE_HIGH_WATERMARK` values unchanged.
+- [ ] Leave the high-watermark abort listener unchanged.
+- [ ] Leave chunk required drain timeout derivation unchanged.
+- [ ] Leave final `waitForPasteDrain("bestEffort", ...)` in place for both chunk and fallback paths.
+- [ ] Do not touch non-paste macro execution.
+
+## Task 5: Verify
+
+**Files:**
+- Read only unless verification reveals a direct issue.
+
+- [ ] Run:
+
+```powershell
+cd ui
+npx tsc --noEmit
+```
+
+- [ ] Run:
+
+```powershell
+cd ui
+npx eslint './src/**/*.{ts,tsx}'
+```
+
+- [ ] If local ESLint reports CRLF prettier drift in pre-existing files, confirm it is the AGENTS.md-known Windows artifact and report it without broad formatting churn.
+
+## Manual Device Checks
+
+These require a JetKVM device and are not expected to run locally in this phase:
+
+- Fresh browser tab, modern firmware, paste >5000 chars: `Chunk 1/N` appears on the first paste and required drains complete.
+- Same tab, second paste >5000 chars: chunk mode remains immediate.
+- Legacy/no-paste-state firmware simulation: first large paste probes for about 2 seconds, silently falls back, and later large pastes skip the probe.
+- Cancel during the first probe aborts immediately and does not set the negative latch.

--- a/docs/superpowers/specs/2026-04-24-first-paste-chunk-probe-design.md
+++ b/docs/superpowers/specs/2026-04-24-first-paste-chunk-probe-design.md
@@ -1,0 +1,147 @@
+# First-Paste Chunk Probe Design
+
+**Issue:** #58, "bug: First paste of every session bypasses Phase 2 chunk-aware safety net (pasteStateSupportObserved gate)"
+**Date:** 2026-04-24
+**Branch:** `fix/phase-3c-first-paste-chunk-probe`
+**Approach:** Oracle Option B, split-phase first-chunk capability probe.
+
+## Problem
+
+Phase 2's large-paste safe mode only enables chunk mode when
+`pasteStateSupportObserved` is already true. That module-level latch flips when
+the frontend observes a `KeyboardMacroStateMessage` with `isPaste=true`.
+
+This protects legacy firmware, but it also means the first large paste in every
+fresh browser session cannot use chunk mode. On modern firmware, that first
+large paste should have the same required drain boundaries as later large
+pastes.
+
+The current gate is:
+
+```typescript
+const chunkMode =
+  rpcHidReady &&
+  pasteStateSupportObserved &&
+  text.length >= policy.autoThresholdChars;
+```
+
+Root cause: the frontend treats "not observed yet" and "not supported" as the
+same state. A fresh modern session starts in "not observed yet", so it takes the
+legacy non-chunk path for the entire first large paste.
+
+## Goals
+
+- First large paste on modern firmware enters chunk mode immediately.
+- The first chunk uses a short probe, about 2 seconds, to observe the first
+  `isPasteInProgress=true` state.
+- If paste state support is observed, normal chunk required drains continue.
+- If the probe times out, chunk mode silently disables for the rest of that
+  paste and a session-local negative latch prevents future probes.
+- Legacy firmware gets no user-visible error and falls back to the existing
+  non-chunk flow after paying the probe cost once per JS session.
+- No localStorage, backend capability bit, or pre-flight character probe.
+
+## Non-Goals
+
+- Do not change Go code or Phase 1 paste-depth semantics.
+- Do not alter `buildPasteMacroBatches()` or the `estimateBatchBytes()` formula.
+- Do not retune paste profiles, watermarks, chunk sizes, queue depths, or the Go
+  200 ms inter-macro drain.
+- Do not add a frontend test harness; that remains Phase 5.
+
+## Design
+
+Keep the implementation in `ui/src/hooks/useKeyboard.ts`.
+
+Add a module-level negative latch:
+
+```typescript
+let pasteStateSupportNegativeLatched = false;
+```
+
+The positive latch, `pasteStateSupportObserved`, remains the source of truth
+once any real paste-state event arrives. The negative latch is only set after a
+large-paste probe times out in this JS session.
+If a paste-state event arrives later in the same session, positive evidence
+clears the negative latch.
+
+Chunk eligibility becomes:
+
+```typescript
+let chunkMode =
+  rpcHidReady &&
+  !pasteStateSupportNegativeLatched &&
+  text.length >= policy.autoThresholdChars;
+```
+
+This lets modern firmware use chunk mode on the first large paste while still
+skipping chunk mode on legacy firmware after one failed probe.
+
+Add a small helper that waits only for paste start, not full drain:
+
+```typescript
+async function waitForPasteStartProbe(timeoutMs: number, signal?: AbortSignal): Promise<boolean>
+```
+
+The helper subscribes before sampling `useHidStore.getState()`, resolves `true`
+when `isPasteInProgress` is true, resolves `false` on timeout, and rejects
+immediately on abort. The abort error message should match the rest of the
+paste path: `"Paste execution aborted"`.
+
+During the chunk loop, arm the probe immediately before dispatching the first
+paste batch when `pasteStateSupportObserved` is still false. After that first
+batch is sent, await the handled probe outcome. If it resolves true, continue
+into the existing required drain logic. If it resolves false, set
+`pasteStateSupportNegativeLatched = true` only if no paste-state evidence has
+arrived, switch `chunkMode` to false for the current paste, switch progress
+chunk fields to zero, and continue sending only the remaining batches from the
+existing chunked plan.
+
+Fallback must not resend already-sent batches. The loop should preserve the
+current `completedBatches` position and rebuild the remaining work as one
+non-chunk segment from the next unsent batch index through `batches.length`.
+
+## User Experience
+
+Modern firmware:
+
+- First large paste shows `Chunk 1/N` immediately.
+- First chunk probe should complete as soon as the backend emits paste start.
+- Required drain boundaries remain active for the first and later chunks.
+
+Legacy firmware:
+
+- First large paste may show chunk progress briefly during the first chunk.
+- After about 2 seconds with no paste-state start, the paste silently continues
+  on the existing non-chunk path.
+- Later large pastes in the same tab skip chunk mode immediately.
+
+## Risks
+
+The main correctness risk is fallback after some batches have already been sent.
+If fallback restarts from batch zero, it duplicates text. If it waits for a
+required drain after the probe already proved no paste-state events are
+available, it reintroduces the legacy timeout failure. The implementation must
+continue from the next unsent batch and use only the final best-effort drain on
+the fallback path.
+
+The secondary risk is abort responsiveness. The new probe must listen to the
+existing `AbortSignal`; cancel during the probe must reject immediately and must
+not set the negative latch.
+
+## Acceptance Criteria
+
+- Fresh-session first paste over `autoThresholdChars` enters chunk mode when
+  `rpcHidReady` is true and no negative latch has been set.
+- The first chunk probes for paste-state start with a short deadline around
+  2 seconds.
+- Probe success preserves normal required drain boundaries.
+- Probe timeout disables chunk mode for only the current paste remainder and
+  latches the no-support result for the JS session.
+- Abort during channel drain, probe, chunk drain, chunk pause, or final drain
+  remains immediate.
+- `ui/src/utils/pasteMacro.ts` remains untouched unless a small pure helper is
+  proven necessary.
+- Verification runs:
+  `cd ui && npx tsc --noEmit`
+  `cd ui && npx eslint './src/**/*.{ts,tsx}'`

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -34,7 +34,7 @@ const MACRO_RESET_KEYBOARD_STATE = {
 
 // Module-level guards for the Phase 2 chunk-aware paste path.
 //
-// `executePasteTextInFlight` is the correctness guard against concurrent
+// `executePasteTextInFlightChannel` is the correctness guard against concurrent
 // executePasteText invocations on the same WebRTC channel. It lives at
 // module scope (not inside useKeyboard or PasteModal) so that even if
 // PasteModal unmounts and remounts between chunks — e.g., when
@@ -55,21 +55,45 @@ const MACRO_RESET_KEYBOARD_STATE = {
 // alone is not a reliable indicator of paste-state support. The negative
 // latch keeps those devices on the safe non-chunk path after they pay the
 // probe cost once per browser session.
-let executePasteTextInFlight = false;
-let pasteStateSupportObserved = false;
+let executePasteTextInFlightChannel: RTCDataChannel | null = null;
 let pasteStateSupportChannel: RTCDataChannel | null = null;
+let pasteStateSupportObserved = false;
 let pasteStateSupportNegativeLatched = false;
 let pasteFailureSequence = 0;
 
-function syncPasteStateSupportChannel(channel: RTCDataChannel | null): boolean {
-  if (pasteStateSupportChannel === channel) {
-    return pasteStateSupportObserved;
-  }
+function syncPasteStateSupportChannel(channel: RTCDataChannel): boolean {
+  if (pasteStateSupportChannel === channel) return false;
   pasteStateSupportChannel = channel;
   pasteStateSupportObserved = false;
   pasteStateSupportNegativeLatched = false;
-  useHidStore.getState().setPasteModeEnabled(false);
-  return false;
+  return true;
+}
+
+function isPasteStateSupportObservedForChannel(channel: RTCDataChannel): boolean {
+  return pasteStateSupportChannel === channel && pasteStateSupportObserved;
+}
+
+function isPasteStateSupportNegativeLatchedForChannel(channel: RTCDataChannel): boolean {
+  return pasteStateSupportChannel === channel && pasteStateSupportNegativeLatched;
+}
+
+function markPasteStateSupportObserved(channel: RTCDataChannel) {
+  if (pasteStateSupportChannel !== channel) return;
+  pasteStateSupportObserved = true;
+  pasteStateSupportNegativeLatched = false;
+}
+
+function markPasteStateSupportNegative(channel: RTCDataChannel) {
+  if (pasteStateSupportChannel !== channel) return;
+  if (!pasteStateSupportObserved) {
+    pasteStateSupportNegativeLatched = true;
+  }
+}
+
+function ensurePasteExecutionChannelCurrent(channel: RTCDataChannel) {
+  if (executePasteTextInFlightChannel !== channel) {
+    throw new Error("Paste data channel changed");
+  }
 }
 
 export interface MacroStep {
@@ -326,11 +350,6 @@ async function waitForPasteStartProbe(timeoutMs: number, signal?: AbortSignal): 
       }
     });
 
-    if (useHidStore.getState().isPasteInProgress) {
-      resolveValue(true);
-      return;
-    }
-
     if (signal?.aborted) {
       rejectErr(new Error("Paste execution aborted"));
       return;
@@ -423,12 +442,13 @@ export default function useKeyboard() {
         // paste-state start event. Positive evidence clears any earlier
         // probe-timeout result from this JS session.
         if (macroState.state) {
-          pasteStateSupportObserved = true;
-          pasteStateSupportNegativeLatched = false;
-        } else if (macroState.failed) {
+          markPasteStateSupportObserved(sourceChannel);
+        } else if (pasteStateSupportChannel === sourceChannel && macroState.failed) {
           pasteFailureSequence++;
         }
-        setPasteModeEnabled(macroState.state);
+        if (pasteStateSupportChannel === sourceChannel) {
+          setPasteModeEnabled(macroState.state);
+        }
         break;
       }
       default:
@@ -730,13 +750,17 @@ export default function useKeyboard() {
       // Module-level concurrency guard. PasteModal also has a local
       // in-flight guard for UI responsiveness, but that guard dies
       // when the popover unmounts (e.g., click-outside dismissal during
-      // a chunk boundary). This flag survives component remounts and
+      // a chunk boundary). This channel identity survives component remounts and
       // is the correctness-level guard against interleaved pastes on
       // the same data channel.
-      if (executePasteTextInFlight) {
+      const channel = rpcHidChannel;
+      if (executePasteTextInFlightChannel !== null && executePasteTextInFlightChannel !== channel) {
+        executePasteTextInFlightChannel = null;
+      }
+      if (executePasteTextInFlightChannel !== null) {
         throw new Error("A paste is already in progress");
       }
-      executePasteTextInFlight = true;
+      executePasteTextInFlightChannel = channel;
       try {
         const {
           keyboard,
@@ -767,11 +791,12 @@ export default function useKeyboard() {
         const PASTE_LOW_WATERMARK = 64 * 1024;
         const PASTE_HIGH_WATERMARK = 256 * 1024;
 
-        const channel = rpcHidChannel;
         if (!channel || channel.readyState !== "open") {
           throw new Error("HID data channel not available");
         }
-        const pasteStateSupportedForChannel = syncPasteStateSupportChannel(channel);
+        if (syncPasteStateSupportChannel(channel)) {
+          setPasteModeEnabled(false);
+        }
 
         // Save and set bufferedAmount threshold for paste flow control
         const prevThreshold = channel.bufferedAmountLowThreshold;
@@ -824,7 +849,7 @@ export default function useKeyboard() {
           const policy = DEFAULT_LARGE_PASTE_POLICY;
           let chunkMode =
             rpcHidReady &&
-            !pasteStateSupportNegativeLatched &&
+            !isPasteStateSupportNegativeLatchedForChannel(channel) &&
             text.length >= policy.autoThresholdChars;
           let chunks: PasteChunkPlan[] = chunkMode
             ? partitionBatchesByChunkChars(batchStats, policy.chunkChars)
@@ -837,7 +862,7 @@ export default function useKeyboard() {
                 },
               ];
           let chunkTotalForProgress = chunkMode ? chunks.length : 0;
-          let pasteStateSupportProvenForPaste = pasteStateSupportedForChannel;
+          let pasteStateSupportProvenForPaste = isPasteStateSupportObservedForChannel(channel);
           let pasteStartProbeOutcome: Promise<{ supported: boolean } | { error: Error }> | null =
             null;
 
@@ -862,6 +887,7 @@ export default function useKeyboard() {
 
               const batch = batches[b];
               await executePasteMacro(batch);
+              ensurePasteExecutionChannelCurrent(channel);
 
               onTrace?.({
                 kind: "batch",
@@ -882,6 +908,7 @@ export default function useKeyboard() {
 
               if (pasteStartProbeOutcome !== null && !pasteStateSupportProvenForPaste) {
                 const probeResult = await pasteStartProbeOutcome;
+                ensurePasteExecutionChannelCurrent(channel);
                 pasteStartProbeOutcome = null;
                 if ("error" in probeResult) {
                   throw probeResult.error;
@@ -889,9 +916,7 @@ export default function useKeyboard() {
                 if (probeResult.supported) {
                   pasteStateSupportProvenForPaste = true;
                 } else {
-                  if (!pasteStateSupportObserved) {
-                    pasteStateSupportNegativeLatched = true;
-                  }
+                  markPasteStateSupportNegative(channel);
                   chunkMode = false;
                   chunkTotalForProgress = 0;
 
@@ -922,6 +947,7 @@ export default function useKeyboard() {
               // pending promise immediately via onBufferedDrainAbort.
               if (channel.bufferedAmount >= PASTE_HIGH_WATERMARK) {
                 await waitForChannelDrain();
+                ensurePasteExecutionChannelCurrent(channel);
               }
             }
 
@@ -1027,6 +1053,7 @@ export default function useKeyboard() {
                   pasteFailureBaseline,
                 );
               }
+              ensurePasteExecutionChannelCurrent(channel);
               onTrace?.({
                 kind: "chunk-drained",
                 chunkIndex: chunk.chunkIndex + 1,
@@ -1051,6 +1078,7 @@ export default function useKeyboard() {
                   pauseMs: policy.chunkPauseMs,
                 });
                 await abortableSleep(policy.chunkPauseMs, signal);
+                ensurePasteExecutionChannelCurrent(channel);
               }
             }
           }
@@ -1076,18 +1104,22 @@ export default function useKeyboard() {
             undefined,
             undefined,
             pasteFailureBaseline,
-            !(rpcHidReady && !chunkMode && batches.length > 0) || pasteStateSupportNegativeLatched,
+            !(rpcHidReady && !chunkMode && batches.length > 0) ||
+              isPasteStateSupportNegativeLatchedForChannel(channel),
           );
+          ensurePasteExecutionChannelCurrent(channel);
         } finally {
           channel.removeEventListener("bufferedamountlow", onLow);
           signal?.removeEventListener("abort", onBufferedDrainAbort);
           channel.bufferedAmountLowThreshold = prevThreshold;
         }
       } finally {
-        executePasteTextInFlight = false;
+        if (executePasteTextInFlightChannel === channel) {
+          executePasteTextInFlightChannel = null;
+        }
       }
     },
-    [executePasteMacro, rpcHidChannel, rpcHidReady],
+    [executePasteMacro, rpcHidChannel, rpcHidReady, setPasteModeEnabled],
   );
 
   const cancelExecuteMacro = useCallback(async () => {

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -46,22 +46,19 @@ const MACRO_RESET_KEYBOARD_STATE = {
 //
 // `pasteStateSupportObserved` tracks whether the device this session is
 // connected to has EVER emitted a KeyboardMacroStateMessage with IsPaste
-// true (set in the useHidRpc onMessage handler below). Chunk mode
-// relies on observing isPasteInProgress transitions via
-// waitForPasteDrain("required", ...), and that only works on Phase 1+
-// devices that emit paste-state messages. Older v1 firmware without
-// Phase 1 still advertises the same HID RPC protocol version (0x01),
-// so `rpcHidReady` alone is not a reliable indicator of paste-state
-// support. Chunk mode gates on this flag, defaulting to the safe
-// non-chunk path until the device proves it sends paste-state events.
-// Consequence: the first paste of a session always runs non-chunk
-// (byte-for-byte identical to pre-Phase-2 behavior); subsequent
-// pastes — chunkable or not — will observe the flag having flipped
-// true during the first paste's drain messages and use chunk mode if
-// the device supports it.
+// true (set in the useHidRpc onMessage handler below).
+//
+// `pasteStateSupportNegativeLatched` tracks the opposite result: this JS
+// session tried the first-chunk paste-state probe and no start event arrived
+// before the short probe deadline. Older v1 firmware without Phase 1 still
+// advertises the same HID RPC protocol version (0x01), so `rpcHidReady`
+// alone is not a reliable indicator of paste-state support. The negative
+// latch keeps those devices on the safe non-chunk path after they pay the
+// probe cost once per browser session.
 let executePasteTextInFlight = false;
 let pasteStateSupportObserved = false;
 let pasteStateSupportChannel: RTCDataChannel | null = null;
+let pasteStateSupportNegativeLatched = false;
 let pasteFailureSequence = 0;
 
 function syncPasteStateSupportChannel(channel: RTCDataChannel | null): boolean {
@@ -70,6 +67,7 @@ function syncPasteStateSupportChannel(channel: RTCDataChannel | null): boolean {
   }
   pasteStateSupportChannel = channel;
   pasteStateSupportObserved = false;
+  pasteStateSupportNegativeLatched = false;
   useHidStore.getState().setPasteModeEnabled(false);
   return false;
 }
@@ -132,6 +130,7 @@ type PasteDrainMode = "required" | "bestEffort";
 
 const PASTE_DRAIN_DEFAULT_ARM_WINDOW_MS = 200;
 const PASTE_DRAIN_DEFAULT_SETTLE_MS = 500;
+const PASTE_STATE_SUPPORT_PROBE_TIMEOUT_MS = 2000;
 
 /**
  * Wait for a paste session to drain from the backend macro queue.
@@ -282,6 +281,65 @@ async function waitForPasteDrain(
 }
 
 /**
+ * Probe whether the current device emits paste-state start messages.
+ *
+ * This is intentionally start-only, not a full drain. It lets the first large
+ * paste of a fresh modern session enter chunk mode immediately, while legacy
+ * firmware can fall back before any required drain waits on events that will
+ * never arrive.
+ */
+async function waitForPasteStartProbe(timeoutMs: number, signal?: AbortSignal): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    let done = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = undefined;
+      }
+      signal?.removeEventListener("abort", onAbort);
+      unsubscribe();
+    };
+
+    const resolveValue = (value: boolean) => {
+      if (done) return;
+      done = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const rejectErr = (err: Error) => {
+      if (done) return;
+      done = true;
+      cleanup();
+      reject(err);
+    };
+
+    const onAbort = () => rejectErr(new Error("Paste execution aborted"));
+
+    const unsubscribe = useHidStore.subscribe(state => {
+      if (state.isPasteInProgress) {
+        resolveValue(true);
+      }
+    });
+
+    if (useHidStore.getState().isPasteInProgress) {
+      resolveValue(true);
+      return;
+    }
+
+    if (signal?.aborted) {
+      rejectErr(new Error("Paste execution aborted"));
+      return;
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    timeoutHandle = setTimeout(() => resolveValue(false), timeoutMs);
+  });
+}
+
+/**
  * Sleep for `ms` milliseconds, rejecting early if `signal` aborts.
  *
  * Used by Phase 2's chunk-aware paste loop to pause between chunks
@@ -360,9 +418,10 @@ export default function useKeyboard() {
         if (!macroState.isPaste) break;
         syncPasteStateSupportChannel(sourceChannel);
         // Latch paste-state support the first time we observe a real
-        // paste-state event. Chunk mode gates on this to avoid hanging
-        // on older v1 firmware that does not emit paste-state events.
+        // paste-state event. Positive evidence clears any earlier
+        // probe-timeout result from this JS session.
         pasteStateSupportObserved = true;
+        pasteStateSupportNegativeLatched = false;
         if (!macroState.state && macroState.failed) {
           pasteFailureSequence++;
         }
@@ -750,39 +809,16 @@ export default function useKeyboard() {
         channel.addEventListener("bufferedamountlow", onLow);
         signal?.addEventListener("abort", onBufferedDrainAbort);
 
-        // Phase 2 chunk policy. Chunk mode is automatic above the threshold,
-        // but ONLY when (a) rpcHidReady is true and (b) the current session
-        // has previously observed a real paste-state event from the device
-        // (pasteStateSupportObserved latched at module scope in the
-        // KeyboardMacroStateMessage handler above). Gating on
-        // pasteStateSupportObserved is load-bearing for compatibility:
-        // - On the legacy client-side path (!rpcHidReady), executePasteMacro
-        //   falls through to executeMacroClientSide which never emits
-        //   paste-state messages.
-        // - On older v1 firmware that has not landed Phase 1 paste-state
-        //   semantics, rpcHidReady is true (the HID RPC channel is open
-        //   and protocol version 0x01 is negotiated) but the device never
-        //   emits KeyboardMacroState events with isPaste=true.
-        // - waitForPasteDrain("required", ...) has no arm window (that's
-        //   bestEffort-only) and waits for an isPasteInProgress 0→1→0
-        //   transition. On either of the above paths, that transition
-        //   never arrives, so a chunk-boundary drain would hang until
-        //   the full derived timeout (60s minimum) before rejecting,
-        //   regressing every large paste to a failure.
-        //
-        // Consequence: the FIRST paste of any session always runs the
-        // non-chunk path regardless of size (byte-for-byte identical to
-        // pre-Phase-2 behavior). During that paste, the bestEffort final
-        // drain waits for isPasteInProgress events — if any arrive, the
-        // latch flips true and subsequent pastes in the session use
-        // chunk mode if they exceed the threshold. If no paste-state
-        // events arrive (legacy/old-firmware device), the latch stays
-        // false and all pastes in the session stay on the non-chunk
-        // path for safety.
+        // Phase 3c chunk policy. Chunk mode is automatic above the threshold
+        // on RPC HID unless this JS session has already probed and found no
+        // paste-state support. A fresh modern session no longer needs a prior
+        // non-chunk paste to arm the positive latch.
         const policy = DEFAULT_LARGE_PASTE_POLICY;
-        const chunkMode =
-          rpcHidReady && pasteStateSupportedForChannel && text.length >= policy.autoThresholdChars;
-        const chunks: PasteChunkPlan[] = chunkMode
+        let chunkMode =
+          rpcHidReady &&
+          !pasteStateSupportNegativeLatched &&
+          text.length >= policy.autoThresholdChars;
+        let chunks: PasteChunkPlan[] = chunkMode
           ? partitionBatchesByChunkChars(batchStats, policy.chunkChars)
           : [
               {
@@ -792,14 +828,29 @@ export default function useKeyboard() {
                 sourceChars: text.length,
               },
             ];
-        const chunkTotalForProgress = chunkMode ? chunks.length : 0;
+        let chunkTotalForProgress = chunkMode ? chunks.length : 0;
+        let pasteStateSupportProvenForPaste = pasteStateSupportedForChannel;
+        let pasteStartProbeOutcome: Promise<{ supported: boolean } | { error: Error }> | null =
+          null;
 
         try {
           for (let ci = 0; ci < chunks.length; ci++) {
             const chunk = chunks[ci];
             for (let b = chunk.batchStartIndex; b < chunk.batchEndIndex; b++) {
-              if (signal?.aborted) {
-                throw new Error("Paste execution aborted");
+              if (
+                chunkMode &&
+                !pasteStateSupportProvenForPaste &&
+                pasteStartProbeOutcome === null
+              ) {
+                pasteStartProbeOutcome = waitForPasteStartProbe(
+                  PASTE_STATE_SUPPORT_PROBE_TIMEOUT_MS,
+                  signal,
+                ).then(
+                  supported => ({ supported }),
+                  error => ({
+                    error: error instanceof Error ? error : new Error(String(error)),
+                  }),
+                );
               }
 
               const batch = batches[b];
@@ -822,6 +873,43 @@ export default function useKeyboard() {
                 chunkTotal: chunkTotalForProgress,
               });
 
+              if (pasteStartProbeOutcome !== null && !pasteStateSupportProvenForPaste) {
+                const probeResult = await pasteStartProbeOutcome;
+                pasteStartProbeOutcome = null;
+                if ("error" in probeResult) {
+                  throw probeResult.error;
+                }
+                if (probeResult.supported) {
+                  pasteStateSupportProvenForPaste = true;
+                } else {
+                  if (!pasteStateSupportObserved) {
+                    pasteStateSupportNegativeLatched = true;
+                  }
+                  chunkMode = false;
+                  chunkTotalForProgress = 0;
+
+                  const remainingBatchStartIndex = b + 1;
+                  if (remainingBatchStartIndex < batches.length) {
+                    let remainingSourceChars = 0;
+                    for (let rb = remainingBatchStartIndex; rb < batches.length; rb++) {
+                      remainingSourceChars += batchStats[rb].sourceChars;
+                    }
+                    chunks = [
+                      {
+                        chunkIndex: 0,
+                        batchStartIndex: remainingBatchStartIndex,
+                        batchEndIndex: batches.length,
+                        sourceChars: remainingSourceChars,
+                      },
+                    ];
+                  } else {
+                    chunks = [];
+                  }
+                  ci = -1;
+                  break;
+                }
+              }
+
               // Pause if channel buffer exceeds high watermark. The wait is
               // abort-aware: signal.abort() during the pause rejects the
               // pending promise immediately via onBufferedDrainAbort.
@@ -834,7 +922,7 @@ export default function useKeyboard() {
             // wait for the backend to fully drain (required mode — rejects on
             // timeout so a chunk-level failure surfaces as an error), then
             // pause if there are more chunks to come.
-            if (chunkMode) {
+            if (chunkMode && pasteStateSupportProvenForPaste) {
               onTrace?.({
                 kind: "chunk-sent",
                 chunkIndex: chunk.chunkIndex + 1,
@@ -981,7 +1069,7 @@ export default function useKeyboard() {
             undefined,
             undefined,
             pasteFailureBaseline,
-            !(rpcHidReady && !chunkMode && batches.length > 0),
+            !(rpcHidReady && !chunkMode && batches.length > 0) || pasteStateSupportNegativeLatched,
           );
         } finally {
           channel.removeEventListener("bufferedamountlow", onLow);

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -45,8 +45,8 @@ const MACRO_RESET_KEYBOARD_STATE = {
 // correctness-level guard is this flag.
 //
 // `pasteStateSupportObserved` tracks whether the device this session is
-// connected to has EVER emitted a KeyboardMacroStateMessage with IsPaste
-// true (set in the useHidRpc onMessage handler below).
+// connected to has EVER emitted an active KeyboardMacroStateMessage with
+// IsPaste true (set in the useHidRpc onMessage handler below).
 //
 // `pasteStateSupportNegativeLatched` tracks the opposite result: this JS
 // session tried the first-chunk paste-state probe and no start event arrived
@@ -192,7 +192,9 @@ async function waitForPasteDrain(
       done = true;
       cleanup();
       // Observed drain → host USB settle delay before the caller resumes.
-      setTimeout(resolve, settleMs);
+      // Keep the settle tail abort-aware even after the drain subscription
+      // has been cleaned up.
+      abortableSleep(settleMs, signal).then(resolve, reject);
     };
 
     const resolveImmediate = () => {
@@ -418,11 +420,12 @@ export default function useKeyboard() {
         if (!macroState.isPaste) break;
         syncPasteStateSupportChannel(sourceChannel);
         // Latch paste-state support the first time we observe a real
-        // paste-state event. Positive evidence clears any earlier
+        // paste-state start event. Positive evidence clears any earlier
         // probe-timeout result from this JS session.
-        pasteStateSupportObserved = true;
-        pasteStateSupportNegativeLatched = false;
-        if (!macroState.state && macroState.failed) {
+        if (macroState.state) {
+          pasteStateSupportObserved = true;
+          pasteStateSupportNegativeLatched = false;
+        } else if (macroState.failed) {
           pasteFailureSequence++;
         }
         setPasteModeEnabled(macroState.state);
@@ -809,31 +812,35 @@ export default function useKeyboard() {
         channel.addEventListener("bufferedamountlow", onLow);
         signal?.addEventListener("abort", onBufferedDrainAbort);
 
-        // Phase 3c chunk policy. Chunk mode is automatic above the threshold
-        // on RPC HID unless this JS session has already probed and found no
-        // paste-state support. A fresh modern session no longer needs a prior
-        // non-chunk paste to arm the positive latch.
-        const policy = DEFAULT_LARGE_PASTE_POLICY;
-        let chunkMode =
-          rpcHidReady &&
-          !pasteStateSupportNegativeLatched &&
-          text.length >= policy.autoThresholdChars;
-        let chunks: PasteChunkPlan[] = chunkMode
-          ? partitionBatchesByChunkChars(batchStats, policy.chunkChars)
-          : [
-              {
-                chunkIndex: 0,
-                batchStartIndex: 0,
-                batchEndIndex: batches.length,
-                sourceChars: text.length,
-              },
-            ];
-        let chunkTotalForProgress = chunkMode ? chunks.length : 0;
-        let pasteStateSupportProvenForPaste = pasteStateSupportedForChannel;
-        let pasteStartProbeOutcome: Promise<{ supported: boolean } | { error: Error }> | null =
-          null;
-
         try {
+          // Phase 3c chunk policy. Chunk mode is automatic above the threshold
+          // on RPC HID unless this JS session has already probed and found no
+          // paste-state support. A fresh modern session no longer needs a prior
+          // non-chunk paste to arm the positive latch.
+          // Legacy/client-side execution is still excluded by rpcHidReady. Older
+          // RPC HID firmware gets one short first-chunk probe; if no paste-state
+          // start arrives, the negative latch sends this paste remainder and
+          // later large pastes through the existing non-chunk path.
+          const policy = DEFAULT_LARGE_PASTE_POLICY;
+          let chunkMode =
+            rpcHidReady &&
+            !pasteStateSupportNegativeLatched &&
+            text.length >= policy.autoThresholdChars;
+          let chunks: PasteChunkPlan[] = chunkMode
+            ? partitionBatchesByChunkChars(batchStats, policy.chunkChars)
+            : [
+                {
+                  chunkIndex: 0,
+                  batchStartIndex: 0,
+                  batchEndIndex: batches.length,
+                  sourceChars: text.length,
+                },
+              ];
+          let chunkTotalForProgress = chunkMode ? chunks.length : 0;
+          let pasteStateSupportProvenForPaste = pasteStateSupportedForChannel;
+          let pasteStartProbeOutcome: Promise<{ supported: boolean } | { error: Error }> | null =
+            null;
+
           for (let ci = 0; ci < chunks.length; ci++) {
             const chunk = chunks[ci];
             for (let b = chunk.batchStartIndex; b < chunk.batchEndIndex; b++) {


### PR DESCRIPTION
Closes #58.
Closes #53.

## Summary

Implements Phase 3c / Oracle Option B for first-paste chunk support and folds in the channel-identity follow-up from #53.

- adds a session-local negative paste-state support latch
- lets first large RPC HID pastes enter chunk mode immediately unless the channel has a negative latch
- arms a short 2s paste-start probe before the first paste batch, then awaits the handled outcome after that batch is dispatched
- on probe success, continues with existing chunk-aware required drain boundaries
- on probe timeout, silently falls back to the existing non-chunk path from the next unsent batch (`b + 1`) and skips future probes for that channel
- scopes `executePasteText` in-flight state to the active `rpcHidChannel` identity
- scopes paste-state support positive/negative latches to the active HID channel and ignores stale old-channel paste-state messages
- prevents old async paste flows from applying probe/drain results after a newer channel owns the paste guard
- adds the Phase 3c spec and implementation plan under `docs/superpowers/`

## Scope

Touched only:

- `ui/src/hooks/useKeyboard.ts`
- `ui/src/hooks/useHidRpc.ts`
- `docs/superpowers/specs/2026-04-24-first-paste-chunk-probe-design.md`
- `docs/superpowers/plans/2026-04-24-first-paste-chunk-probe.md`

No Go files, package files, localStorage, backend capability bit, pre-flight character probe, or paste profile retuning.

## Verification

- `cd ui && npm run test:unit -- src/hooks/hidRpc.test.ts src/utils/pasteMacro.test.ts src/utils/pasteBatches.test.ts`
- `cd ui && npx tsc --noEmit --pretty false`
- `cd ui && npx eslint './src/hooks/useKeyboard.ts' './src/hooks/useHidRpc.ts'`
- `git diff --check -- ui/src/hooks/useKeyboard.ts ui/src/hooks/useHidRpc.ts`
- GitHub Actions on the rebased branch: `UI Lint` passed and `golangci-lint / lint` passed

## Manual device testing still needed

- modern firmware, fresh browser tab, first >5000-char paste shows `Chunk 1/N` immediately
- modern firmware, second large paste in same tab skips the probe via positive latch
- legacy/no-paste-state firmware or simulation: first large paste probes ~2s, silently falls back, and subsequent large pastes skip probing
- deterministic marker payload confirms fallback sends every batch exactly once
- cancel during probe, channel drain, required drain, chunk pause, and final drain clears the channel-owned paste guard promptly

## Current Blocker

Still blocked on reachable JetKVM hardware validation. As of 2026-05-01, `jetkvm.local` does not resolve, `192.168.1.36` is unreachable on ICMP/22/80, and `192.168.1.188` rejects current `root` SSH auth.