### PR TITLE
fix(webrtc): serialize HID queue teardown

### DIFF
--- a/internal/regression/webrtc_hidqueue_lock_test.go
+++ b/internal/regression/webrtc_hidqueue_lock_test.go
@@ -1,0 +1,228 @@
+package regression
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHIDQueueSendAndCloseAreSerialized(t *testing.T) {
+	fset := token.NewFileSet()
+	sourcePath := filepath.Join("..", "..", "webrtc.go")
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read webrtc.go: %v", err)
+	}
+	file, err := parser.ParseFile(fset, sourcePath, source, 0)
+	if err != nil {
+		t.Fatalf("parse webrtc.go: %v", err)
+	}
+
+	handler := webrtcFindFunc(file, "getOnHidMessageHandler")
+	if handler == nil {
+		t.Fatal("getOnHidMessageHandler not found")
+	}
+	if webrtcContainsIdent(handler.Body, "recover") {
+		t.Fatal("getOnHidMessageHandler still uses recover for HID queue send; serialize send/close under hidQueueLock instead")
+	}
+	if !webrtcContainsMethodCall(handler.Body, "session", "enqueueHIDQueueMessage") {
+		t.Fatal("getOnHidMessageHandler must enqueue HID messages through enqueueHIDQueueMessage")
+	}
+
+	hidEnqueue := webrtcFindFunc(file, "enqueueHIDQueueMessage")
+	if hidEnqueue == nil {
+		t.Fatal("enqueueHIDQueueMessage not found")
+	}
+	if !webrtcContainsSelectorCall(hidEnqueue.Body, "s", "hidQueueLock", "Lock") ||
+		!webrtcContainsSelectorCall(hidEnqueue.Body, "s", "hidQueueLock", "Unlock") {
+		t.Fatal("enqueueHIDQueueMessage must hold s.hidQueueLock while reading and sending to hidQueue")
+	}
+	if !webrtcContainsSendToIdent(hidEnqueue.Body, "queue") {
+		t.Fatal("enqueueHIDQueueMessage must send to the selected hidQueue while its defer unlock is active")
+	}
+	if !webrtcUnlocksOnlyWithDefer(hidEnqueue.Body, "s") {
+		t.Fatal("enqueueHIDQueueMessage must keep hidQueueLock held until function return")
+	}
+
+	keysDown := webrtcFindFunc(file, "enqueueKeysDownState")
+	if keysDown == nil {
+		t.Fatal("enqueueKeysDownState not found")
+	}
+	if !webrtcContainsSelectorCall(keysDown.Body, "s", "hidQueueLock", "Lock") ||
+		!webrtcContainsSelectorCall(keysDown.Body, "s", "hidQueueLock", "Unlock") {
+		t.Fatal("enqueueKeysDownState must hold s.hidQueueLock while checking/sending to keysDownStateQueue")
+	}
+	if !webrtcContainsSendToSelector(keysDown.Body, "s", "keysDownStateQueue") {
+		t.Fatal("enqueueKeysDownState must send to s.keysDownStateQueue under hidQueueLock")
+	}
+	if !webrtcUnlocksOnlyWithDefer(keysDown.Body, "s") {
+		t.Fatal("enqueueKeysDownState must keep hidQueueLock held until function return")
+	}
+
+	closeQueues := webrtcFindFunc(file, "closeHIDQueues")
+	if closeQueues == nil {
+		t.Fatal("closeHIDQueues not found")
+	}
+	if !webrtcContainsSelectorCall(closeQueues.Body, "s", "hidQueueLock", "Lock") ||
+		!webrtcContainsSelectorCall(closeQueues.Body, "s", "hidQueueLock", "Unlock") {
+		t.Fatal("closeHIDQueues must hold s.hidQueueLock while closing HID queues")
+	}
+	if webrtcCountCalls(closeQueues.Body, "close") < 2 {
+		t.Fatal("closeHIDQueues must close both hidQueue entries and keysDownStateQueue")
+	}
+	if !webrtcUnlocksOnlyWithDefer(closeQueues.Body, "s") {
+		t.Fatal("closeHIDQueues must keep hidQueueLock held until function return")
+	}
+	if !webrtcContainsMethodCall(file, "session", "closeHIDQueues") {
+		t.Fatal("session teardown must close HID queues through closeHIDQueues")
+	}
+}
+
+func webrtcFindFunc(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+func webrtcContainsIdent(node ast.Node, name string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if ok && ident.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func webrtcContainsSelectorCall(node ast.Node, root, field, method string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if webrtcIsNestedSelector(call.Fun, root, field, method) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func webrtcContainsMethodCall(node ast.Node, root, method string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != method {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if ok && ident.Name == root {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func webrtcUnlocksOnlyWithDefer(node ast.Node, root string) bool {
+	var unlockCalls int
+	var deferredUnlocks int
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch typed := n.(type) {
+		case *ast.CallExpr:
+			if webrtcIsNestedSelector(typed.Fun, root, "hidQueueLock", "Unlock") {
+				unlockCalls++
+			}
+		case *ast.DeferStmt:
+			if webrtcIsNestedSelector(typed.Call.Fun, root, "hidQueueLock", "Unlock") {
+				deferredUnlocks++
+			}
+		}
+		return true
+	})
+	return unlockCalls == 1 && deferredUnlocks == 1
+}
+
+func webrtcContainsSendToIdent(node ast.Node, name string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		send, ok := n.(*ast.SendStmt)
+		if !ok {
+			return true
+		}
+		ident, ok := send.Chan.(*ast.Ident)
+		if ok && ident.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func webrtcContainsSendToSelector(node ast.Node, root, field string) bool {
+	found := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		send, ok := n.(*ast.SendStmt)
+		if !ok {
+			return true
+		}
+		selector, ok := send.Chan.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != field {
+			return true
+		}
+		ident, ok := selector.X.(*ast.Ident)
+		if ok && ident.Name == root {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func webrtcCountCalls(node ast.Node, name string) int {
+	var count int
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if ok && ident.Name == name {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+func webrtcIsNestedSelector(expr ast.Expr, root, field, method string) bool {
+	outer, ok := expr.(*ast.SelectorExpr)
+	if !ok || outer.Sel.Name != method {
+		return false
+	}
+	inner, ok := outer.X.(*ast.SelectorExpr)
+	if !ok || inner.Sel.Name != field {
+		return false
+	}
+	ident, ok := inner.X.(*ast.Ident)
+	return ok && ident.Name == root
+}

--- a/webrtc.go
+++ b/webrtc.go
@@ -173,28 +173,58 @@ func (s *Session) initQueues() {
 	}
 }
 
-func (s *Session) handleQueues(index int) {
-	for msg := range s.hidQueue[index] {
+func (s *Session) handleQueues(queue <-chan hidQueueMessage) {
+	for msg := range queue {
 		onHidMessage(msg, s)
 	}
+}
+
+func (s *Session) enqueueHIDQueueMessage(queueIndex int, msg hidQueueMessage) (int, bool) {
+	s.hidQueueLock.Lock()
+	defer s.hidQueueLock.Unlock()
+
+	if queueIndex >= len(s.hidQueue) || queueIndex < 0 {
+		queueIndex = 3
+	}
+	if queueIndex >= len(s.hidQueue) {
+		return queueIndex, false
+	}
+
+	queue := s.hidQueue[queueIndex]
+	if queue == nil {
+		return queueIndex, false
+	}
+
+	queue <- msg
+	return queueIndex, true
 }
 
 const keysDownStateQueueSize = 64
 
 func (s *Session) initKeysDownStateQueue() {
 	// serialise outbound key state reports so unreliable links can't stall input handling
-	s.keysDownStateQueue = make(chan usbgadget.KeysDownState, keysDownStateQueueSize)
-	go s.handleKeysDownStateQueue()
+	s.hidQueueLock.Lock()
+	queue := make(chan usbgadget.KeysDownState, keysDownStateQueueSize)
+	s.keysDownStateQueue = queue
+	s.hidQueueLock.Unlock()
+	go s.handleKeysDownStateQueue(queue)
 }
 
-func (s *Session) handleKeysDownStateQueue() {
-	for state := range s.keysDownStateQueue {
+func (s *Session) handleKeysDownStateQueue(queue <-chan usbgadget.KeysDownState) {
+	for state := range queue {
 		s.reportHidRPCKeysDownState(state)
 	}
 }
 
 func (s *Session) enqueueKeysDownState(state usbgadget.KeysDownState) {
-	if s == nil || s.keysDownStateQueue == nil {
+	if s == nil {
+		return
+	}
+
+	s.hidQueueLock.Lock()
+	defer s.hidQueueLock.Unlock()
+
+	if s.keysDownStateQueue == nil {
 		return
 	}
 
@@ -203,6 +233,23 @@ func (s *Session) enqueueKeysDownState(state usbgadget.KeysDownState) {
 	default:
 		hidRPCLogger.Warn().Msg("dropping keys down state update; queue full")
 	}
+}
+
+func (s *Session) closeHIDQueues() {
+	s.hidQueueLock.Lock()
+	defer s.hidQueueLock.Unlock()
+
+	for i := 0; i < len(s.hidQueue); i++ {
+		if s.hidQueue[i] != nil {
+			close(s.hidQueue[i])
+		}
+		s.hidQueue[i] = nil
+	}
+
+	if s.keysDownStateQueue != nil {
+		close(s.keysDownStateQueue)
+	}
+	s.keysDownStateQueue = nil
 }
 
 func getOnHidMessageHandler(session *Session, scopedLogger *zerolog.Logger, channel string) func(msg webrtc.DataChannelMessage) {
@@ -230,36 +277,15 @@ func getOnHidMessageHandler(session *Session, scopedLogger *zerolog.Logger, chan
 
 		// Enqueue to ensure ordered processing
 		queueIndex := hidrpc.GetQueueIndex(hidrpc.MessageType(msg.Data[0]))
-		if queueIndex >= len(session.hidQueue) || queueIndex < 0 {
+		actualQueueIndex, enqueued := session.enqueueHIDQueueMessage(queueIndex, hidQueueMessage{
+			DataChannelMessage: msg,
+			channel:            channel,
+		})
+		if actualQueueIndex != queueIndex {
 			l.Warn().Int("queueIndex", queueIndex).Msg("received data in HID RPC message handler, but queue index not found")
-			queueIndex = 3
 		}
-
-		queue := session.hidQueue[queueIndex]
-		if queue != nil {
-			// Defensive: session teardown closes session.hidQueue[i] at
-			// webrtc.go:440-443 without holding hidQueueLock, while the pion
-			// readLoop goroutine may deliver one last buffered message from
-			// the wire after the close. The unsynchronized close-vs-send race
-			// produces "send on closed channel". Recover here so a late
-			// message during teardown drops with a warning instead of
-			// panicking the whole app. Proper fix is to serialize close and
-			// send under hidQueueLock — tracked as a follow-up.
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						l.Warn().
-							Interface("recover", r).
-							Msg("hidQueue send panicked (channel closed during session teardown); message dropped")
-					}
-				}()
-				queue <- hidQueueMessage{
-					DataChannelMessage: msg,
-					channel:            channel,
-				}
-			}()
-		} else {
-			l.Warn().Int("queueIndex", queueIndex).Msg("received data in HID RPC message handler, but queue is nil")
+		if !enqueued {
+			l.Warn().Int("queueIndex", actualQueueIndex).Msg("received data in HID RPC message handler, but queue is nil or unavailable")
 			return
 		}
 	}
@@ -343,8 +369,11 @@ func newSession(config SessionConfig) (*Session, error) {
 		}
 	}()
 
-	for i := 0; i < len(session.hidQueue); i++ {
-		go session.handleQueues(i)
+	session.hidQueueLock.Lock()
+	hidQueues := append([]chan hidQueueMessage(nil), session.hidQueue...)
+	session.hidQueueLock.Unlock()
+	for _, queue := range hidQueues {
+		go session.handleQueues(queue)
 	}
 
 	peerConnection.OnDataChannel(func(d *webrtc.DataChannel) {
@@ -454,13 +483,7 @@ func newSession(config SessionConfig) (*Session, error) {
 			}
 
 			// Stop HID RPC processor
-			for i := 0; i < len(session.hidQueue); i++ {
-				close(session.hidQueue[i])
-				session.hidQueue[i] = nil
-			}
-
-			close(session.keysDownStateQueue)
-			session.keysDownStateQueue = nil
+			session.closeHIDQueues()
 
 			if session.shouldUmountVirtualMedia {
 				if err := rpcUnmountImage(); err != nil {


### PR DESCRIPTION
## Summary

- replace the HID queue send-on-closed-channel `recover` bandaid with serialized queue send/close under `hidQueueLock`
- route HID queue send through `enqueueHIDQueueMessage` so queue lookup and blocking send share the close lock
- apply the same lifecycle lock to `keysDownStateQueue` send/close
- capture queue channel references before range goroutines start, so teardown can nil session fields without changing what the goroutines range
- add an independent regression test that verifies the handler/teardown use the locked helpers and that helper unlocks remain deferred

Closes #51.

## Validation

- `wsl.exe bash -lc "gofmt -l webrtc.go internal/regression/webrtc_hidqueue_lock_test.go && go test -count=1 ./internal/regression"`
- `git diff --check`

## Notes

This intentionally keeps issue #51 Option A behavior: the HID queue send remains blocking while holding `hidQueueLock`, using the buffered queue as backpressure. Teardown calls `cancelAndDrainMacroQueue()` before closing HID queues, so macro enqueue pressure is released before the close path waits on the same lock.

Full root package compile was not run from this Windows worktree because the repo requires generated UI embed output and native C artifacts first.