### PR TITLE
fix(paste): report macro execution failures

### DIFF
--- a/hidrpc.go
+++ b/hidrpc.go
@@ -229,7 +229,7 @@ func reportHidRPC(params any, session *Session) {
 	case usbgadget.KeysDownState:
 		message, err = hidrpc.NewKeydownStateMessage(params).Marshal()
 	case hidrpc.KeyboardMacroState:
-		message, err = hidrpc.NewKeyboardMacroStateMessage(params.State, params.IsPaste).Marshal()
+		message, err = hidrpc.NewKeyboardMacroStateMessage(params.State, params.IsPaste, params.Failed).Marshal()
 	default:
 		err = fmt.Errorf("unknown HID RPC message type: %T", params)
 	}

--- a/internal/hidrpc/hidrpc.go
+++ b/internal/hidrpc/hidrpc.go
@@ -107,13 +107,16 @@ func NewKeydownStateMessage(state usbgadget.KeysDownState) *Message {
 }
 
 // NewKeyboardMacroStateMessage creates a new keyboard macro state message.
-func NewKeyboardMacroStateMessage(state bool, isPaste bool) *Message {
-	data := make([]byte, 2)
+func NewKeyboardMacroStateMessage(state bool, isPaste bool, failed bool) *Message {
+	data := make([]byte, 3)
 	if state {
 		data[0] = 1
 	}
 	if isPaste {
 		data[1] = 1
+	}
+	if failed {
+		data[2] = 1
 	}
 
 	return &Message{

--- a/internal/hidrpc/message.go
+++ b/internal/hidrpc/message.go
@@ -192,6 +192,7 @@ func (m *Message) MouseReport() (MouseReport, error) {
 type KeyboardMacroState struct {
 	State   bool
 	IsPaste bool
+	Failed  bool
 }
 
 // KeyboardMacroState returns the keyboard macro state report from the message.
@@ -199,9 +200,13 @@ func (m *Message) KeyboardMacroState() (KeyboardMacroState, error) {
 	if m.t != TypeKeyboardMacroState {
 		return KeyboardMacroState{}, fmt.Errorf("invalid message type: %d", m.t)
 	}
+	if len(m.d) < 2 {
+		return KeyboardMacroState{}, fmt.Errorf("invalid keyboard macro state data length: %d", len(m.d))
+	}
 
 	return KeyboardMacroState{
 		State:   m.d[0] == uint8(1),
 		IsPaste: m.d[1] == uint8(1),
+		Failed:  len(m.d) >= 3 && m.d[2] == uint8(1),
 	}, nil
 }

--- a/internal/hidrpc/message_test.go
+++ b/internal/hidrpc/message_test.go
@@ -1,0 +1,55 @@
+package hidrpc
+
+import "testing"
+
+func TestKeyboardMacroStateMessageIncludesFailureFlag(t *testing.T) {
+	message := NewKeyboardMacroStateMessage(false, true, true)
+
+	data, err := message.Marshal()
+	if err != nil {
+		t.Fatalf("marshal keyboard macro state: %v", err)
+	}
+
+	want := []byte{byte(TypeKeyboardMacroState), 0, 1, 1}
+	if string(data) != string(want) {
+		t.Fatalf("unexpected keyboard macro state payload: got %v, want %v", data, want)
+	}
+
+	var decoded Message
+	if err := Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal keyboard macro state: %v", err)
+	}
+	state, err := decoded.KeyboardMacroState()
+	if err != nil {
+		t.Fatalf("decode keyboard macro state: %v", err)
+	}
+	if state.State || !state.IsPaste || !state.Failed {
+		t.Fatalf("unexpected keyboard macro state: %+v", state)
+	}
+}
+
+func TestKeyboardMacroStateMessageReadsLegacyPayloadWithoutFailure(t *testing.T) {
+	var decoded Message
+	if err := Unmarshal([]byte{byte(TypeKeyboardMacroState), 0, 1}, &decoded); err != nil {
+		t.Fatalf("unmarshal legacy keyboard macro state: %v", err)
+	}
+
+	state, err := decoded.KeyboardMacroState()
+	if err != nil {
+		t.Fatalf("decode legacy keyboard macro state: %v", err)
+	}
+	if state.State || !state.IsPaste || state.Failed {
+		t.Fatalf("unexpected legacy keyboard macro state: %+v", state)
+	}
+}
+
+func TestKeyboardMacroStateMessageRejectsMalformedPayload(t *testing.T) {
+	var decoded Message
+	if err := Unmarshal([]byte{byte(TypeKeyboardMacroState), 1}, &decoded); err != nil {
+		t.Fatalf("unmarshal malformed keyboard macro state: %v", err)
+	}
+
+	if _, err := decoded.KeyboardMacroState(); err == nil {
+		t.Fatal("expected malformed keyboard macro state to fail")
+	}
+}

--- a/internal/regression/paste_failure_state_test.go
+++ b/internal/regression/paste_failure_state_test.go
@@ -1,0 +1,55 @@
+package regression
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readRepoFile(t *testing.T, parts ...string) string {
+	t.Helper()
+	path := filepath.Join(append([]string{"..", ".."}, parts...)...)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func requireContains(t *testing.T, source string, want string) {
+	t.Helper()
+	if !strings.Contains(source, want) {
+		t.Fatalf("expected source to contain:\n%s", want)
+	}
+}
+
+func TestPasteFailureStateIsReportedOnFinalPasteEdge(t *testing.T) {
+	source := readRepoFile(t, "jsonrpc.go")
+
+	requireContains(t, source, "pasteFailures atomic.Int32")
+	requireContains(t, source, "if item.isPaste && !errors.Is(err, context.Canceled) {\n\t\t\t\tpasteFailures.Add(1)\n\t\t\t}")
+	requireContains(t, source, "emitPasteState(item.session, false, pasteFailures.Swap(0) > 0)")
+	requireContains(t, source, "emitPasteState(lastPasteSession, false, pasteFailures.Swap(0) > 0)")
+	requireContains(t, source, "pasteFailures.Store(0)")
+	requireContains(t, source, "emitPasteState(session, true, false)")
+	requireContains(t, source, "emitPasteState(session, false, pasteFailures.Swap(0) > 0)")
+}
+
+func TestFrontendRejectsObservedPasteFailureAndTimeout(t *testing.T) {
+	hidRPC := readRepoFile(t, "ui", "src", "hooks", "hidRpc.ts")
+	keyboard := readRepoFile(t, "ui", "src", "hooks", "useKeyboard.ts")
+
+	requireContains(t, hidRPC, "failed: boolean;")
+	requireContains(t, hidRPC, "data[2] === 1")
+	requireContains(t, keyboard, "let pasteFailureSequence = 0;")
+	requireContains(t, keyboard, "let pasteStateSupportChannel: RTCDataChannel | null = null;")
+	requireContains(t, keyboard, "sourceChannel !== useRTCStore.getState().rpcHidChannel")
+	requireContains(t, keyboard, "rejectErr(new Error(\"Paste macro failed\"));")
+	requireContains(t, keyboard, "pasteFailureSequence++;")
+	requireContains(t, keyboard, "if (mode === \"required\" || seenTrue)")
+	requireContains(t, keyboard, "allowNoStartFastPath = true")
+	requireContains(t, keyboard, "mode === \"bestEffort\" && !seenTrue && allowNoStartFastPath")
+	requireContains(t, keyboard, "!(rpcHidReady && !chunkMode && batches.length > 0)")
+	requireContains(t, keyboard, "pasteFailureBaseline")
+}

--- a/internal/regression/paste_failure_state_test.go
+++ b/internal/regression/paste_failure_state_test.go
@@ -14,7 +14,7 @@ func readRepoFile(t *testing.T, parts ...string) string {
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}
-	return string(data)
+	return strings.ReplaceAll(string(data), "\r\n", "\n")
 }
 
 func requireContains(t *testing.T, source string, want string) {

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1050,6 +1050,12 @@ var (
 	// transition. Non-paste macros never touch this counter.
 	pasteDepth atomic.Int32
 
+	// pasteFailures counts non-cancel execution failures observed during the
+	// current paste-depth session. The final 1->0 paste-state emit reports
+	// whether any macro in the session failed so the frontend can reject the
+	// paste instead of treating State:false as success.
+	pasteFailures atomic.Int32
+
 	// macroEnqueueCtx is the cancellation context for blocking enqueues.
 	// It is owned by the macro queue (not by any handler or session) and is
 	// rotated by cancelAndDrainMacroQueue so that enqueuers blocked on a full
@@ -1087,13 +1093,14 @@ func currentEnqueueCtx() context.Context {
 // respectively). If the session is nil (origin session torn down between
 // enqueue and drain), this silently no-ops — the frontend on the new
 // session will reconcile state through its own fresh subscription.
-func emitPasteState(session *Session, state bool) {
+func emitPasteState(session *Session, state bool, failed bool) {
 	if session == nil {
 		return
 	}
 	session.reportHidRPCKeyboardMacroState(hidrpc.KeyboardMacroState{
 		State:   state,
 		IsPaste: true,
+		Failed:  failed,
 	})
 }
 
@@ -1119,6 +1126,9 @@ func drainMacroQueue() {
 		err := rpcDoExecuteKeyboardMacro(ctx, item.steps)
 		if err != nil {
 			logger.Warn().Uint64("macro_id", macroID).Err(err).Msg("queued keyboard macro failed")
+			if item.isPaste && !errors.Is(err, context.Canceled) {
+				pasteFailures.Add(1)
+			}
 		} else {
 			logger.Info().Uint64("macro_id", macroID).Msg("queued keyboard macro completed")
 		}
@@ -1134,7 +1144,7 @@ func drainMacroQueue() {
 		if item.isPaste {
 			if pasteDepth.Add(-1) == 0 {
 				logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 1->0 (drain complete)")
-				emitPasteState(item.session, false)
+				emitPasteState(item.session, false, pasteFailures.Swap(0) > 0)
 			}
 		}
 
@@ -1205,7 +1215,7 @@ func cancelAndDrainMacroQueue() {
 		logger.Debug().Int32("discarded_paste", discardedPaste).Msg("cancel sweep discarded paste macros")
 		if pasteDepth.Add(-discardedPaste) == 0 {
 			logger.Debug().Msg("paste-depth 1->0 (cancel sweep)")
-			emitPasteState(lastPasteSession, false)
+			emitPasteState(lastPasteSession, false, pasteFailures.Swap(0) > 0)
 		}
 	}
 }
@@ -1231,8 +1241,9 @@ func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep,
 	// Emit State:true if this Add is the 0→1 transition.
 	if isPaste {
 		if pasteDepth.Add(1) == 1 {
+			pasteFailures.Store(0)
 			logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 0->1 (enqueue)")
-			emitPasteState(session, true)
+			emitPasteState(session, true, false)
 		}
 	}
 
@@ -1247,7 +1258,7 @@ func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep,
 		if isPaste {
 			if pasteDepth.Add(-1) == 0 {
 				logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 1->0 (enqueue rollback)")
-				emitPasteState(session, false)
+				emitPasteState(session, false, pasteFailures.Swap(0) > 0)
 			}
 		}
 		return ctx.Err()

--- a/ui/src/hooks/hidRpc.ts
+++ b/ui/src/hooks/hidRpc.ts
@@ -261,23 +261,30 @@ export class KeyboardMacroReportMessage extends RpcMessage {
 export class KeyboardMacroStateMessage extends RpcMessage {
   state: boolean;
   isPaste: boolean;
+  failed: boolean;
 
-  constructor(state: boolean, isPaste: boolean) {
+  constructor(state: boolean, isPaste: boolean, failed = false) {
     super(HID_RPC_MESSAGE_TYPES.KeyboardMacroState);
     this.state = state;
     this.isPaste = isPaste;
+    this.failed = failed;
   }
 
   marshal(): Uint8Array {
-    return new Uint8Array([this.messageType, this.state ? 1 : 0, this.isPaste ? 1 : 0]);
+    return new Uint8Array([
+      this.messageType,
+      this.state ? 1 : 0,
+      this.isPaste ? 1 : 0,
+      this.failed ? 1 : 0,
+    ]);
   }
 
   public static unmarshal(data: Uint8Array): KeyboardMacroStateMessage | undefined {
-    if (data.length < 1) {
+    if (data.length < 2) {
       throw new Error(`Invalid keyboard macro state report message length: ${data.length}`);
     }
 
-    return new KeyboardMacroStateMessage(data[0] === 1, data[1] === 1);
+    return new KeyboardMacroStateMessage(data[0] === 1, data[1] === 1, data[2] === 1);
   }
 }
 

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -159,7 +159,9 @@ export function doRpcHidHandshake(
   }
 }
 
-export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
+export function useHidRpc(
+  onHidRpcMessage?: (payload: RpcMessage, channel: RTCDataChannel) => void,
+) {
   const {
     rpcHidChannel,
     rpcHidUnreliableChannel,
@@ -299,7 +301,7 @@ export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
       // setting `esbuild.pure` doesn't work
       /* @__PURE__ */ logger.debug("Received message", message);
 
-      onHidRpcMessage?.(message);
+      onHidRpcMessage?.(message, rpcHidChannel);
     };
 
     const errorHandler = (e: Event) => {

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -61,6 +61,18 @@ const MACRO_RESET_KEYBOARD_STATE = {
 // the device supports it.
 let executePasteTextInFlight = false;
 let pasteStateSupportObserved = false;
+let pasteStateSupportChannel: RTCDataChannel | null = null;
+let pasteFailureSequence = 0;
+
+function syncPasteStateSupportChannel(channel: RTCDataChannel | null): boolean {
+  if (pasteStateSupportChannel === channel) {
+    return pasteStateSupportObserved;
+  }
+  pasteStateSupportChannel = channel;
+  pasteStateSupportObserved = false;
+  useHidStore.getState().setPasteModeEnabled(false);
+  return false;
+}
 
 export interface MacroStep {
   keys: string[] | null;
@@ -125,9 +137,11 @@ const PASTE_DRAIN_DEFAULT_SETTLE_MS = 500;
  * Wait for a paste session to drain from the backend macro queue.
  *
  * Modes:
- * - "bestEffort" — resolves on timeout or on the arm window (if no paste ever
- *   started). Preserves the existing final-settle UX from executePasteText.
- *   Used by Phase 1's final-drain call site.
+ * - "bestEffort" — resolves on timeout or on the arm window only while no
+ *   paste has been observed. Once a paste start is observed, timeout rejects
+ *   so a supported backend cannot report success before a late failed
+ *   completion event arrives. Callers can disable the no-start arm window
+ *   when a supported first paste may emit state after the default arm window.
  * - "required" — rejects on timeout, never takes the arm-window fast path.
  *   Reserved for #38's chunk boundaries in Phase 2. No Phase 1 call sites.
  *
@@ -151,12 +165,15 @@ async function waitForPasteDrain(
   signal?: AbortSignal,
   settleMs: number = PASTE_DRAIN_DEFAULT_SETTLE_MS,
   armWindowMs: number = PASTE_DRAIN_DEFAULT_ARM_WINDOW_MS,
+  failureSequenceBaseline: number = pasteFailureSequence,
+  allowNoStartFastPath = true,
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     let done = false;
     let seenTrue = false;
     let armHandle: ReturnType<typeof setTimeout> | undefined;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let unsubscribe: () => void = () => undefined;
 
     const cleanup = () => {
       if (armHandle !== undefined) {
@@ -195,10 +212,17 @@ async function waitForPasteDrain(
 
     const onAbort = () => rejectErr(new Error("Paste execution aborted"));
 
+    const rejectIfPasteFailed = () => {
+      if (pasteFailureSequence === failureSequenceBaseline) return false;
+      rejectErr(new Error("Paste macro failed"));
+      return true;
+    };
+
     // Subscribe FIRST. Every store update runs this callback; we update
     // the `seenTrue` latch on truthy updates and only take the clean-drain
     // exit on a falsy update AFTER seenTrue has been latched.
-    const unsubscribe = useHidStore.subscribe(state => {
+    unsubscribe = useHidStore.subscribe(state => {
+      if (rejectIfPasteFailed()) return;
       if (state.isPasteInProgress) {
         seenTrue = true;
         return;
@@ -214,6 +238,10 @@ async function waitForPasteDrain(
     // If no change happened, we pick up whatever the store says right now.
     seenTrue = useHidStore.getState().isPasteInProgress;
 
+    if (rejectIfPasteFailed()) {
+      return;
+    }
+
     // Fast-reject if the caller already aborted before we even started.
     if (signal?.aborted) {
       rejectErr(new Error("Paste execution aborted"));
@@ -223,10 +251,11 @@ async function waitForPasteDrain(
     signal?.addEventListener("abort", onAbort, { once: true });
 
     timeoutHandle = setTimeout(() => {
-      if (mode === "required") {
-        rejectErr(new Error(`waitForPasteDrain: required drain timed out after ${timeoutMs}ms`));
+      if (rejectIfPasteFailed()) return;
+      if (mode === "required" || seenTrue) {
+        rejectErr(new Error(`waitForPasteDrain: paste drain timed out after ${timeoutMs}ms`));
       } else {
-        // bestEffort: treat timeout as success, skip settle.
+        // bestEffort with no observed paste: treat timeout as success, skip settle.
         resolveImmediate();
       }
     }, timeoutMs);
@@ -236,9 +265,10 @@ async function waitForPasteDrain(
     // isPasteInProgress === false AND seenTrue is still false, assume
     // the paste never materialized and resolve. If the store has gone
     // true during the window, flip seenTrue and defer to the subscription.
-    if (mode === "bestEffort" && !seenTrue) {
+    if (mode === "bestEffort" && !seenTrue && allowNoStartFastPath) {
       armHandle = setTimeout(() => {
         armHandle = undefined;
+        if (rejectIfPasteFailed()) return;
         if (useHidStore.getState().isPasteInProgress) {
           seenTrue = true;
           return;
@@ -316,7 +346,7 @@ export default function useKeyboard() {
     reportKeypressKeepAlive: sendKeypressKeepAliveHidRpc,
     rpcHidChannel,
     rpcHidReady,
-  } = useHidRpc(message => {
+  } = useHidRpc((message, sourceChannel) => {
     switch (message.constructor) {
       case KeysDownStateMessage:
         setKeysDownState((message as KeysDownStateMessage).keysDownState);
@@ -324,14 +354,21 @@ export default function useKeyboard() {
       case KeyboardLedStateMessage:
         setKeyboardLedState((message as KeyboardLedStateMessage).keyboardLedState);
         break;
-      case KeyboardMacroStateMessage:
-        if (!(message as KeyboardMacroStateMessage).isPaste) break;
+      case KeyboardMacroStateMessage: {
+        if (sourceChannel !== useRTCStore.getState().rpcHidChannel) break;
+        const macroState = message as KeyboardMacroStateMessage;
+        if (!macroState.isPaste) break;
+        syncPasteStateSupportChannel(sourceChannel);
         // Latch paste-state support the first time we observe a real
         // paste-state event. Chunk mode gates on this to avoid hanging
         // on older v1 firmware that does not emit paste-state events.
         pasteStateSupportObserved = true;
-        setPasteModeEnabled((message as KeyboardMacroStateMessage).state);
+        if (!macroState.state && macroState.failed) {
+          pasteFailureSequence++;
+        }
+        setPasteModeEnabled(macroState.state);
         break;
+      }
       default:
         break;
     }
@@ -639,299 +676,318 @@ export default function useKeyboard() {
       }
       executePasteTextInFlight = true;
       try {
-      const {
-        keyboard,
-        delayMs,
-        maxStepsPerBatch,
-        maxBytesPerBatch,
-        finalSettleMs,
-        signal,
-        onProgress,
-        onTrace,
-      } = options;
+        const {
+          keyboard,
+          delayMs,
+          maxStepsPerBatch,
+          maxBytesPerBatch,
+          finalSettleMs,
+          signal,
+          onProgress,
+          onTrace,
+        } = options;
 
-      const { batches, invalidChars, batchStats } = buildPasteMacroBatches(
-        text,
-        keyboard,
-        delayMs,
-        maxStepsPerBatch,
-        maxBytesPerBatch,
-      );
+        const { batches, invalidChars, batchStats } = buildPasteMacroBatches(
+          text,
+          keyboard,
+          delayMs,
+          maxStepsPerBatch,
+          maxBytesPerBatch,
+        );
 
-      if (invalidChars.length > 0) {
-        throw new Error(`Unsupported characters: ${invalidChars.join(", ")}`);
-      }
+        if (invalidChars.length > 0) {
+          throw new Error(`Unsupported characters: ${invalidChars.join(", ")}`);
+        }
 
-      // Pipeline flow control constants. Values untouched in Phase 2.
-      const PASTE_LOW_WATERMARK = 64 * 1024;
-      const PASTE_HIGH_WATERMARK = 256 * 1024;
+        const pasteFailureBaseline = pasteFailureSequence;
 
-      const channel = rpcHidChannel;
-      if (!channel || channel.readyState !== "open") {
-        throw new Error("HID data channel not available");
-      }
+        // Pipeline flow control constants. Values untouched in Phase 2.
+        const PASTE_LOW_WATERMARK = 64 * 1024;
+        const PASTE_HIGH_WATERMARK = 256 * 1024;
 
-      // Save and set bufferedAmount threshold for paste flow control
-      const prevThreshold = channel.bufferedAmountLowThreshold;
-      channel.bufferedAmountLowThreshold = PASTE_LOW_WATERMARK;
+        const channel = rpcHidChannel;
+        if (!channel || channel.readyState !== "open") {
+          throw new Error("HID data channel not available");
+        }
+        const pasteStateSupportedForChannel = syncPasteStateSupportChannel(channel);
 
-      // Abort-aware high-watermark drain wait. Phase 2 upgrade over the
-      // pre-existing drainResolve-only pattern: if signal.abort() fires
-      // while the loop is parked on a full channel buffer, the pending
-      // waitForChannelDrain() rejects immediately rather than waiting
-      // for the next bufferedamountlow event. drainReject is the paired
-      // slot; onBufferedDrainAbort is installed alongside the existing
-      // onLow listener. The low-watermark resume path is unchanged —
-      // onLow still fires on bufferedamountlow and resolves the pending
-      // promise exactly as before.
-      let drainResolve: (() => void) | null = null;
-      let drainReject: ((err: Error) => void) | null = null;
-      const waitForChannelDrain = () =>
-        new Promise<void>((resolve, reject) => {
-          if (signal?.aborted) {
-            reject(new Error("Paste execution aborted"));
-            return;
-          }
-          drainResolve = resolve;
-          drainReject = reject;
-        });
-      const onLow = () => {
-        const resolver = drainResolve;
-        drainResolve = null;
-        drainReject = null;
-        resolver?.();
-      };
-      const onBufferedDrainAbort = () => {
-        const rejecter = drainReject;
-        drainResolve = null;
-        drainReject = null;
-        rejecter?.(new Error("Paste execution aborted"));
-      };
-      channel.addEventListener("bufferedamountlow", onLow);
-      signal?.addEventListener("abort", onBufferedDrainAbort);
+        // Save and set bufferedAmount threshold for paste flow control
+        const prevThreshold = channel.bufferedAmountLowThreshold;
+        channel.bufferedAmountLowThreshold = PASTE_LOW_WATERMARK;
 
-      // Phase 2 chunk policy. Chunk mode is automatic above the threshold,
-      // but ONLY when (a) rpcHidReady is true and (b) the current session
-      // has previously observed a real paste-state event from the device
-      // (pasteStateSupportObserved latched at module scope in the
-      // KeyboardMacroStateMessage handler above). Gating on
-      // pasteStateSupportObserved is load-bearing for compatibility:
-      // - On the legacy client-side path (!rpcHidReady), executePasteMacro
-      //   falls through to executeMacroClientSide which never emits
-      //   paste-state messages.
-      // - On older v1 firmware that has not landed Phase 1 paste-state
-      //   semantics, rpcHidReady is true (the HID RPC channel is open
-      //   and protocol version 0x01 is negotiated) but the device never
-      //   emits KeyboardMacroState events with isPaste=true.
-      // - waitForPasteDrain("required", ...) has no arm window (that's
-      //   bestEffort-only) and waits for an isPasteInProgress 0→1→0
-      //   transition. On either of the above paths, that transition
-      //   never arrives, so a chunk-boundary drain would hang until
-      //   the full derived timeout (60s minimum) before rejecting,
-      //   regressing every large paste to a failure.
-      //
-      // Consequence: the FIRST paste of any session always runs the
-      // non-chunk path regardless of size (byte-for-byte identical to
-      // pre-Phase-2 behavior). During that paste, the bestEffort final
-      // drain waits for isPasteInProgress events — if any arrive, the
-      // latch flips true and subsequent pastes in the session use
-      // chunk mode if they exceed the threshold. If no paste-state
-      // events arrive (legacy/old-firmware device), the latch stays
-      // false and all pastes in the session stay on the non-chunk
-      // path for safety.
-      const policy = DEFAULT_LARGE_PASTE_POLICY;
-      const chunkMode =
-        rpcHidReady &&
-        pasteStateSupportObserved &&
-        text.length >= policy.autoThresholdChars;
-      const chunks: PasteChunkPlan[] = chunkMode
-        ? partitionBatchesByChunkChars(batchStats, policy.chunkChars)
-        : [
-            {
-              chunkIndex: 0,
-              batchStartIndex: 0,
-              batchEndIndex: batches.length,
-              sourceChars: text.length,
-            },
-          ];
-      const chunkTotalForProgress = chunkMode ? chunks.length : 0;
-
-      try {
-        for (let ci = 0; ci < chunks.length; ci++) {
-          const chunk = chunks[ci];
-          for (let b = chunk.batchStartIndex; b < chunk.batchEndIndex; b++) {
+        // Abort-aware high-watermark drain wait. Phase 2 upgrade over the
+        // pre-existing drainResolve-only pattern: if signal.abort() fires
+        // while the loop is parked on a full channel buffer, the pending
+        // waitForChannelDrain() rejects immediately rather than waiting
+        // for the next bufferedamountlow event. drainReject is the paired
+        // slot; onBufferedDrainAbort is installed alongside the existing
+        // onLow listener. The low-watermark resume path is unchanged —
+        // onLow still fires on bufferedamountlow and resolves the pending
+        // promise exactly as before.
+        let drainResolve: (() => void) | null = null;
+        let drainReject: ((err: Error) => void) | null = null;
+        const waitForChannelDrain = () =>
+          new Promise<void>((resolve, reject) => {
             if (signal?.aborted) {
-              throw new Error("Paste execution aborted");
+              reject(new Error("Paste execution aborted"));
+              return;
             }
+            drainResolve = resolve;
+            drainReject = reject;
+          });
+        const onLow = () => {
+          const resolver = drainResolve;
+          drainResolve = null;
+          drainReject = null;
+          resolver?.();
+        };
+        const onBufferedDrainAbort = () => {
+          const rejecter = drainReject;
+          drainResolve = null;
+          drainReject = null;
+          rejecter?.(new Error("Paste execution aborted"));
+        };
+        channel.addEventListener("bufferedamountlow", onLow);
+        signal?.addEventListener("abort", onBufferedDrainAbort);
 
-            const batch = batches[b];
-            await executePasteMacro(batch);
+        // Phase 2 chunk policy. Chunk mode is automatic above the threshold,
+        // but ONLY when (a) rpcHidReady is true and (b) the current session
+        // has previously observed a real paste-state event from the device
+        // (pasteStateSupportObserved latched at module scope in the
+        // KeyboardMacroStateMessage handler above). Gating on
+        // pasteStateSupportObserved is load-bearing for compatibility:
+        // - On the legacy client-side path (!rpcHidReady), executePasteMacro
+        //   falls through to executeMacroClientSide which never emits
+        //   paste-state messages.
+        // - On older v1 firmware that has not landed Phase 1 paste-state
+        //   semantics, rpcHidReady is true (the HID RPC channel is open
+        //   and protocol version 0x01 is negotiated) but the device never
+        //   emits KeyboardMacroState events with isPaste=true.
+        // - waitForPasteDrain("required", ...) has no arm window (that's
+        //   bestEffort-only) and waits for an isPasteInProgress 0→1→0
+        //   transition. On either of the above paths, that transition
+        //   never arrives, so a chunk-boundary drain would hang until
+        //   the full derived timeout (60s minimum) before rejecting,
+        //   regressing every large paste to a failure.
+        //
+        // Consequence: the FIRST paste of any session always runs the
+        // non-chunk path regardless of size (byte-for-byte identical to
+        // pre-Phase-2 behavior). During that paste, the bestEffort final
+        // drain waits for isPasteInProgress events — if any arrive, the
+        // latch flips true and subsequent pastes in the session use
+        // chunk mode if they exceed the threshold. If no paste-state
+        // events arrive (legacy/old-firmware device), the latch stays
+        // false and all pastes in the session stay on the non-chunk
+        // path for safety.
+        const policy = DEFAULT_LARGE_PASTE_POLICY;
+        const chunkMode =
+          rpcHidReady && pasteStateSupportedForChannel && text.length >= policy.autoThresholdChars;
+        const chunks: PasteChunkPlan[] = chunkMode
+          ? partitionBatchesByChunkChars(batchStats, policy.chunkChars)
+          : [
+              {
+                chunkIndex: 0,
+                batchStartIndex: 0,
+                batchEndIndex: batches.length,
+                sourceChars: text.length,
+              },
+            ];
+        const chunkTotalForProgress = chunkMode ? chunks.length : 0;
 
-            onTrace?.({
-              kind: "batch",
-              batchIndex: b + 1,
-              totalBatches: batches.length,
-              stepCount: batch.length,
-              estimatedBytes: estimateBatchBytes(batch.length),
-              bufferedAmount: channel.bufferedAmount,
-            });
-
-            onProgress?.({
-              completedBatches: b + 1,
-              totalBatches: batches.length,
-              phase: "sending",
-              chunkIndex: chunkMode ? chunk.chunkIndex + 1 : 0,
-              chunkTotal: chunkTotalForProgress,
-            });
-
-            // Pause if channel buffer exceeds high watermark. The wait is
-            // abort-aware: signal.abort() during the pause rejects the
-            // pending promise immediately via onBufferedDrainAbort.
-            if (channel.bufferedAmount >= PASTE_HIGH_WATERMARK) {
-              await waitForChannelDrain();
-            }
-          }
-
-          // Chunk-boundary work: only in chunk mode. Announce the chunk,
-          // wait for the backend to fully drain (required mode — rejects on
-          // timeout so a chunk-level failure surfaces as an error), then
-          // pause if there are more chunks to come.
-          if (chunkMode) {
-            onTrace?.({
-              kind: "chunk-sent",
-              chunkIndex: chunk.chunkIndex + 1,
-              chunkTotal: chunks.length,
-              sourceChars: chunk.sourceChars,
-              batches: chunk.batchEndIndex - chunk.batchStartIndex,
-            });
-
-            // "draining" progress fires while we wait for the backend to
-            // finish the chunk, NOT "pausing" — that was the original
-            // framing but it misrepresents the state to the user on slow
-            // targets where the drain wait can take tens of seconds. The
-            // "pausing" phase is emitted separately below, right before
-            // the explicit inter-chunk abortableSleep.
-            onProgress?.({
-              completedBatches: chunk.batchEndIndex,
-              totalBatches: batches.length,
-              phase: "draining",
-              chunkIndex: chunk.chunkIndex + 1,
-              chunkTotal: chunks.length,
-            });
-
-            // Per-chunk derived drain timeout. A flat constant does not
-            // work here: at reliable-profile pacing on current main
-            // (keyDelayMs=3, 5ms press + 3ms reset per MacroStep, ~66
-            // steps/batch byte-limited, 200ms inter-macro), a 5000-char
-            // chunk takes ~55s end-to-end. The derivation below gives
-            // each chunk ~2x its measured worst case, with a policy
-            // floor for small chunks.
-            //
-            // The derivation reads delayMs from ExecutePasteTextOptions
-            // and applies the SAME `|| 25` fallback that executeMacroRemote
-            // uses for MacroStep.delay. This matters for debug-mode pastes
-            // where the PasteModal delay input can be 0 (slider at 0) or
-            // NaN (empty input). Without the fallback, delayMs=0 would
-            // halve the derived budget and delayMs=NaN would collapse the
-            // whole expression to NaN, making Math.max short-circuit and
-            // the required drain fire almost immediately. The `|| 25`
-            // matches executeMacroRemote's step.delay || 25 at line 456
-            // of this file — same expression, same default, same source
-            // of truth.
-            const effectiveResetDelayMs = delayMs || 25;
-            const perMacroStepBackendMs = (5 + effectiveResetDelayMs) * 2;
-            const perBatchInterMacroMs = 400;
-            let chunkStepCount = 0;
+        try {
+          for (let ci = 0; ci < chunks.length; ci++) {
+            const chunk = chunks[ci];
             for (let b = chunk.batchStartIndex; b < chunk.batchEndIndex; b++) {
-              chunkStepCount += batchStats[b].stepCount;
-            }
-            const chunkNumBatches = chunk.batchEndIndex - chunk.batchStartIndex;
-            const derivedDrainTimeoutMs =
-              chunkStepCount * perMacroStepBackendMs +
-              chunkNumBatches * perBatchInterMacroMs +
-              5000;
-            const chunkDrainTimeoutMs = Math.max(
-              policy.chunkDrainTimeoutFloorMs,
-              derivedDrainTimeoutMs,
-            );
+              if (signal?.aborted) {
+                throw new Error("Paste execution aborted");
+              }
 
-            // Intermediate chunks (ci < chunks.length - 1) skip the
-            // 500ms settle delay because chunkPauseMs (default 2000ms)
-            // is the explicit inter-chunk catch-up pause, so adding a
-            // 500ms settle on top doubles cancel latency without
-            // buying correctness — on a 100k paste with ~20 chunks
-            // that's ~10s of hidden latency.
-            //
-            // The LAST chunk keeps the default settle (undefined →
-            // PASTE_DRAIN_DEFAULT_SETTLE_MS = 500ms) because without
-            // it, the tail of the final chunk loses the existing
-            // host-settle grace period. The subsequent final
-            // bestEffort drain sees isPasteInProgress already false
-            // and takes the 200ms arm-window fast path, so without a
-            // settle on the last required drain the total post-drain
-            // grace collapses from ~500ms (pre-Phase-2) to ~200ms,
-            // which can cause end-of-paste tail corruption on slower
-            // targets. Preserving the settle on the last chunk
-            // restores the pre-Phase-2 settle behavior for that tail.
-            const drainStart = performance.now();
-            const isLastChunk = ci === chunks.length - 1;
-            if (isLastChunk) {
-              await waitForPasteDrain("required", chunkDrainTimeoutMs, signal);
-            } else {
-              await waitForPasteDrain(
-                "required",
-                chunkDrainTimeoutMs,
-                signal,
-                0,
-              );
-            }
-            onTrace?.({
-              kind: "chunk-drained",
-              chunkIndex: chunk.chunkIndex + 1,
-              drainMs: Math.round(performance.now() - drainStart),
-            });
+              const batch = batches[b];
+              await executePasteMacro(batch);
 
-            if (ci < chunks.length - 1) {
-              // "pausing" progress fires here, right before the explicit
-              // inter-chunk sleep — this is the real catch-up window
-              // (Codex iter 3 flagged that previously this phase was
-              // emitted earlier and incorrectly spanned the drain wait).
+              onTrace?.({
+                kind: "batch",
+                batchIndex: b + 1,
+                totalBatches: batches.length,
+                stepCount: batch.length,
+                estimatedBytes: estimateBatchBytes(batch.length),
+                bufferedAmount: channel.bufferedAmount,
+              });
+
+              onProgress?.({
+                completedBatches: b + 1,
+                totalBatches: batches.length,
+                phase: "sending",
+                chunkIndex: chunkMode ? chunk.chunkIndex + 1 : 0,
+                chunkTotal: chunkTotalForProgress,
+              });
+
+              // Pause if channel buffer exceeds high watermark. The wait is
+              // abort-aware: signal.abort() during the pause rejects the
+              // pending promise immediately via onBufferedDrainAbort.
+              if (channel.bufferedAmount >= PASTE_HIGH_WATERMARK) {
+                await waitForChannelDrain();
+              }
+            }
+
+            // Chunk-boundary work: only in chunk mode. Announce the chunk,
+            // wait for the backend to fully drain (required mode — rejects on
+            // timeout so a chunk-level failure surfaces as an error), then
+            // pause if there are more chunks to come.
+            if (chunkMode) {
+              onTrace?.({
+                kind: "chunk-sent",
+                chunkIndex: chunk.chunkIndex + 1,
+                chunkTotal: chunks.length,
+                sourceChars: chunk.sourceChars,
+                batches: chunk.batchEndIndex - chunk.batchStartIndex,
+              });
+
+              // "draining" progress fires while we wait for the backend to
+              // finish the chunk, NOT "pausing" — that was the original
+              // framing but it misrepresents the state to the user on slow
+              // targets where the drain wait can take tens of seconds. The
+              // "pausing" phase is emitted separately below, right before
+              // the explicit inter-chunk abortableSleep.
               onProgress?.({
                 completedBatches: chunk.batchEndIndex,
                 totalBatches: batches.length,
-                phase: "pausing",
+                phase: "draining",
                 chunkIndex: chunk.chunkIndex + 1,
                 chunkTotal: chunks.length,
               });
+
+              // Per-chunk derived drain timeout. A flat constant does not
+              // work here: at reliable-profile pacing on current main
+              // (keyDelayMs=3, 5ms press + 3ms reset per MacroStep, ~66
+              // steps/batch byte-limited, 200ms inter-macro), a 5000-char
+              // chunk takes ~55s end-to-end. The derivation below gives
+              // each chunk ~2x its measured worst case, with a policy
+              // floor for small chunks.
+              //
+              // The derivation reads delayMs from ExecutePasteTextOptions
+              // and applies the SAME `|| 25` fallback that executeMacroRemote
+              // uses for MacroStep.delay. This matters for debug-mode pastes
+              // where the PasteModal delay input can be 0 (slider at 0) or
+              // NaN (empty input). Without the fallback, delayMs=0 would
+              // halve the derived budget and delayMs=NaN would collapse the
+              // whole expression to NaN, making Math.max short-circuit and
+              // the required drain fire almost immediately. The `|| 25`
+              // matches executeMacroRemote's step.delay || 25 at line 456
+              // of this file — same expression, same default, same source
+              // of truth.
+              const effectiveResetDelayMs = delayMs || 25;
+              const perMacroStepBackendMs = (5 + effectiveResetDelayMs) * 2;
+              const perBatchInterMacroMs = 400;
+              let chunkStepCount = 0;
+              for (let b = chunk.batchStartIndex; b < chunk.batchEndIndex; b++) {
+                chunkStepCount += batchStats[b].stepCount;
+              }
+              const chunkNumBatches = chunk.batchEndIndex - chunk.batchStartIndex;
+              const derivedDrainTimeoutMs =
+                chunkStepCount * perMacroStepBackendMs +
+                chunkNumBatches * perBatchInterMacroMs +
+                5000;
+              const chunkDrainTimeoutMs = Math.max(
+                policy.chunkDrainTimeoutFloorMs,
+                derivedDrainTimeoutMs,
+              );
+
+              // Intermediate chunks (ci < chunks.length - 1) skip the
+              // 500ms settle delay because chunkPauseMs (default 2000ms)
+              // is the explicit inter-chunk catch-up pause, so adding a
+              // 500ms settle on top doubles cancel latency without
+              // buying correctness — on a 100k paste with ~20 chunks
+              // that's ~10s of hidden latency.
+              //
+              // The LAST chunk keeps the default settle (undefined →
+              // PASTE_DRAIN_DEFAULT_SETTLE_MS = 500ms) because without
+              // it, the tail of the final chunk loses the existing
+              // host-settle grace period. The subsequent final
+              // bestEffort drain sees isPasteInProgress already false
+              // and takes the 200ms arm-window fast path, so without a
+              // settle on the last required drain the total post-drain
+              // grace collapses from ~500ms (pre-Phase-2) to ~200ms,
+              // which can cause end-of-paste tail corruption on slower
+              // targets. Preserving the settle on the last chunk
+              // restores the pre-Phase-2 settle behavior for that tail.
+              const drainStart = performance.now();
+              const isLastChunk = ci === chunks.length - 1;
+              if (isLastChunk) {
+                await waitForPasteDrain(
+                  "required",
+                  chunkDrainTimeoutMs,
+                  signal,
+                  undefined,
+                  undefined,
+                  pasteFailureBaseline,
+                );
+              } else {
+                await waitForPasteDrain(
+                  "required",
+                  chunkDrainTimeoutMs,
+                  signal,
+                  0,
+                  undefined,
+                  pasteFailureBaseline,
+                );
+              }
               onTrace?.({
-                kind: "chunk-pause",
+                kind: "chunk-drained",
                 chunkIndex: chunk.chunkIndex + 1,
-                pauseMs: policy.chunkPauseMs,
+                drainMs: Math.round(performance.now() - drainStart),
               });
-              await abortableSleep(policy.chunkPauseMs, signal);
+
+              if (ci < chunks.length - 1) {
+                // "pausing" progress fires here, right before the explicit
+                // inter-chunk sleep — this is the real catch-up window
+                // (Codex iter 3 flagged that previously this phase was
+                // emitted earlier and incorrectly spanned the drain wait).
+                onProgress?.({
+                  completedBatches: chunk.batchEndIndex,
+                  totalBatches: batches.length,
+                  phase: "pausing",
+                  chunkIndex: chunk.chunkIndex + 1,
+                  chunkTotal: chunks.length,
+                });
+                onTrace?.({
+                  kind: "chunk-pause",
+                  chunkIndex: chunk.chunkIndex + 1,
+                  pauseMs: policy.chunkPauseMs,
+                });
+                await abortableSleep(policy.chunkPauseMs, signal);
+              }
             }
           }
+
+          // Final bestEffort drain — preserves existing settle UX. In chunk
+          // mode the last chunk's required drain already confirmed HID-layer
+          // drain; this is a short grace window for any residual settle. In
+          // non-chunk mode this is the final backend completion signal when
+          // paste-state support has been observed.
+          onProgress?.({
+            completedBatches: batches.length,
+            totalBatches: batches.length,
+            phase: "draining",
+            chunkIndex: chunkMode ? chunks.length : 0,
+            chunkTotal: chunkTotalForProgress,
+          });
+
+          const drainTimeoutMs = Math.max(finalSettleMs, batches.length * 1000);
+          await waitForPasteDrain(
+            "bestEffort",
+            drainTimeoutMs,
+            signal,
+            undefined,
+            undefined,
+            pasteFailureBaseline,
+            !(rpcHidReady && !chunkMode && batches.length > 0),
+          );
+        } finally {
+          channel.removeEventListener("bufferedamountlow", onLow);
+          signal?.removeEventListener("abort", onBufferedDrainAbort);
+          channel.bufferedAmountLowThreshold = prevThreshold;
         }
-
-        // Final bestEffort drain — preserves existing settle UX. In chunk
-        // mode the last chunk's required drain already confirmed HID-layer
-        // drain; this is a short grace window for any residual settle. In
-        // non-chunk mode this is the existing path verbatim.
-        onProgress?.({
-          completedBatches: batches.length,
-          totalBatches: batches.length,
-          phase: "draining",
-          chunkIndex: chunkMode ? chunks.length : 0,
-          chunkTotal: chunkTotalForProgress,
-        });
-
-        const drainTimeoutMs = Math.max(finalSettleMs, batches.length * 1000);
-        await waitForPasteDrain("bestEffort", drainTimeoutMs, signal);
-      } finally {
-        channel.removeEventListener("bufferedamountlow", onLow);
-        signal?.removeEventListener("abort", onBufferedDrainAbort);
-        channel.bufferedAmountLowThreshold = prevThreshold;
-      }
       } finally {
         executePasteTextInFlight = false;
       }


### PR DESCRIPTION
## Summary
- extend KeyboardMacroState with a backward-compatible failed flag
- aggregate non-cancel paste execution failures on the backend and emit failed=true on the final paste 1->0 edge
- reject frontend paste drains when a failed completion is observed, including first-paste/non-chunk HID paths
- scope paste-state support to the active HID channel and ignore stale-channel macro-state messages
- add HID RPC wire tests and static regression coverage for the paste failure invariants

Closes #32.

## Verification
- `wsl.exe bash -lc "go test ./internal/hidrpc ./internal/regression"`
- `cd ui && npx tsc --noEmit`
- `cd ui && npx eslint './src/hooks/hidRpc.ts' './src/hooks/useHidRpc.ts' './src/hooks/useKeyboard.ts'`
- `git diff --check` (clean aside from Windows `core.autocrlf` warnings)
- GPT-5.5 xhigh subagent review: final pass returned no findings

## Notes
- Full root-package Go tests are not runnable in this Windows worktree without generated `static` embed/native artifacts (`web.go: pattern all:static: no matching files found`).
- UI dependencies were installed with local Node v24.14.1, which reports the repo's expected engine as `^22.21.1`.
