### PR TITLE
fix(paste): harden cancel teardown

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -477,10 +477,13 @@ func handleSessionRequest(
 	cloudLogger.Info().Interface("session", session).Msg("new session accepted")
 	cloudLogger.Trace().Interface("session", session).Msg("new session accepted")
 
-	// Cancel any ongoing keyboard macro when session changes
+	currentSession = session
+
+	// Cancel any ongoing keyboard macro when session changes. Assigning the
+	// new current session first makes late HID messages from the old page stale
+	// immediately while queuedMacro.session still routes final paste-state emits.
 	cancelAndDrainMacroQueue()
 
-	currentSession = session
 	_ = wsjson.Write(context.Background(), c, gin.H{"type": "answer", "data": sd})
 	return nil
 }

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -36,7 +36,7 @@ func handleHidRPCMessage(message hidrpc.Message, session *Session) {
 		}
 		rpcErr = rpcExecuteKeyboardMacro(session, keyboardMacroReport.Steps, keyboardMacroReport.IsPaste)
 	case hidrpc.TypeCancelKeyboardMacroReport:
-		rpcCancelKeyboardMacro()
+		rpcCancelKeyboardMacro(session)
 		return
 	case hidrpc.TypeKeypressKeepAliveReport:
 		rpcErr = handleHidRPCKeypressKeepAlive(session)

--- a/internal/regression/paste_cancel_teardown_test.go
+++ b/internal/regression/paste_cancel_teardown_test.go
@@ -1,0 +1,78 @@
+package regression
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func requireNotContains(t *testing.T, source string, unwanted string) {
+	t.Helper()
+	if strings.Contains(source, unwanted) {
+		t.Fatalf("expected source not to contain:\n%s", unwanted)
+	}
+}
+
+func TestPasteCancelForcesKeyboardReleaseAndRejectsStaleSessions(t *testing.T) {
+	source := readRepoFile(t, "jsonrpc.go")
+
+	requireContains(t, source, "func forceKeyboardAllKeysUp(reason string)")
+	requireContains(t, source, "rpcKeyboardReport(0, keyboardClearStateKeys)")
+	requireContains(t, source, "func isStalePasteSession(session *Session) bool")
+	requireContains(t, source, "func isStaleQueuedMacro(item queuedMacro) bool")
+	requireContains(t, source, "return item.isPaste && isStalePasteSession(item.session)")
+	requireContains(t, source, "rejecting stale-session paste macro")
+	requireContains(t, source, "return context.Canceled")
+	requireNotContains(t, source, "forceKeyboardAllKeysUp(\"stale paste macro enqueue\")")
+	requireContains(t, source, "func rpcCancelKeyboardMacro(session *Session)")
+	requireContains(t, source, "ignoring stale-session keyboard macro cancel")
+	requireContains(t, source, "discarding stale-session queued keyboard macro")
+	requireContains(t, source, "forceKeyboardAllKeysUp(\"stale paste macro discard\")")
+	requireContains(t, source, "forceKeyboardAllKeysUp(\"canceled paste macro\")")
+	requireContains(t, source, "forceKeyboardAllKeysUp(\"macro queue cancel\")")
+	requireContains(t, source, "time.Sleep(pasteInterMacroDrain)")
+}
+
+func TestHidRpcCancelIsScopedToOriginSession(t *testing.T) {
+	source := readRepoFile(t, "hidrpc.go")
+
+	requireContains(t, source, "rpcCancelKeyboardMacro(session)")
+}
+
+func TestSessionSwitchMarksOldPasteWorkStaleBeforeCancelSweep(t *testing.T) {
+	for _, parts := range [][]string{
+		{"web.go"},
+		{"cloud.go"},
+	} {
+		source := readRepoFile(t, parts...)
+		assignIndex := strings.Index(source, "currentSession = session")
+		cancelIndex := strings.Index(source, "cancelAndDrainMacroQueue()")
+		if assignIndex < 0 || cancelIndex < 0 {
+			t.Fatalf("%s missing currentSession assignment or cancel sweep", filepath.Join(parts...))
+		}
+		if assignIndex > cancelIndex {
+			t.Fatalf("%s cancels before assigning currentSession; late old-session paste work can look current", filepath.Join(parts...))
+		}
+	}
+
+	source := readRepoFile(t, "webrtc.go")
+	nilIndex := strings.Index(source, "currentSession = nil")
+	cancelIndex := strings.Index(source, "cancelAndDrainMacroQueue()")
+	if nilIndex < 0 || cancelIndex < 0 {
+		t.Fatal("webrtc.go missing currentSession nil assignment or cancel sweep")
+	}
+	if nilIndex > cancelIndex {
+		t.Fatal("webrtc.go cancels before clearing currentSession; late closing-session paste work can look current")
+	}
+}
+
+func TestFrontendPasteLoopGuardsHidChannelIdentity(t *testing.T) {
+	source := readRepoFile(t, "ui", "src", "hooks", "useKeyboard.ts")
+
+	requireContains(t, source, "let executePasteTextInFlightChannel: RTCDataChannel | null = null;")
+	requireContains(t, source, "function ensurePasteExecutionChannelCurrent(channel: RTCDataChannel): void")
+	requireContains(t, source, "useRTCStore.getState().rpcHidChannel !== channel")
+	requireContains(t, source, "throw new Error(\"Paste HID data channel changed\")")
+	requireContains(t, source, "executePasteTextInFlightChannel === channel")
+	requireContains(t, source, "ensurePasteExecutionChannelCurrent(channel);")
+}

--- a/internal/regression/paste_failure_state_test.go
+++ b/internal/regression/paste_failure_state_test.go
@@ -1,34 +1,14 @@
 package regression
 
-import (
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-)
-
-func readRepoFile(t *testing.T, parts ...string) string {
-	t.Helper()
-	path := filepath.Join(append([]string{"..", ".."}, parts...)...)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
-	return strings.ReplaceAll(string(data), "\r\n", "\n")
-}
-
-func requireContains(t *testing.T, source string, want string) {
-	t.Helper()
-	if !strings.Contains(source, want) {
-		t.Fatalf("expected source to contain:\n%s", want)
-	}
-}
+import "testing"
 
 func TestPasteFailureStateIsReportedOnFinalPasteEdge(t *testing.T) {
 	source := readRepoFile(t, "jsonrpc.go")
 
 	requireContains(t, source, "pasteFailures atomic.Int32")
-	requireContains(t, source, "if item.isPaste && !errors.Is(err, context.Canceled) {\n\t\t\t\tpasteFailures.Add(1)\n\t\t\t}")
+	requireContains(t, source, "if item.isPaste {\n\t\t\t\tif errors.Is(err, context.Canceled) {")
+	requireContains(t, source, "forceKeyboardAllKeysUp(\"canceled paste macro\")")
+	requireContains(t, source, "} else {\n\t\t\t\t\tpasteFailures.Add(1)\n\t\t\t\t}")
 	requireContains(t, source, "emitPasteState(item.session, false, pasteFailures.Swap(0) > 0)")
 	requireContains(t, source, "emitPasteState(lastPasteSession, false, pasteFailures.Swap(0) > 0)")
 	requireContains(t, source, "pasteFailures.Store(0)")

--- a/internal/regression/source_assertions_test.go
+++ b/internal/regression/source_assertions_test.go
@@ -1,0 +1,25 @@
+package regression
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readRepoFile(t *testing.T, parts ...string) string {
+	t.Helper()
+	path := filepath.Join(append([]string{"..", ".."}, parts...)...)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return strings.ReplaceAll(string(data), "\r\n", "\n")
+}
+
+func requireContains(t *testing.T, source string, want string) {
+	t.Helper()
+	if !strings.Contains(source, want) {
+		t.Fatalf("expected source to contain:\n%s", want)
+	}
+}

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1104,6 +1104,22 @@ func emitPasteState(session *Session, state bool, failed bool) {
 	})
 }
 
+func forceKeyboardAllKeysUp(reason string) {
+	if err := rpcKeyboardReport(0, keyboardClearStateKeys); err != nil {
+		logger.Warn().Err(err).Str("reason", reason).Msg("failed to force keyboard all-keys-up")
+		return
+	}
+	logger.Debug().Str("reason", reason).Msg("forced keyboard all-keys-up")
+}
+
+func isStalePasteSession(session *Session) bool {
+	return session != nil && session != currentSession
+}
+
+func isStaleQueuedMacro(item queuedMacro) bool {
+	return item.isPaste && isStalePasteSession(item.session)
+}
+
 // drainMacroQueue is the sole consumer of macroQueue. It executes each macro
 // sequentially. Paste-session state transitions (State:true / State:false) are
 // emitted on atomic pasteDepth 0↔1 edges, not per macro — see rpcExecuteKeyboardMacro
@@ -1117,6 +1133,22 @@ func drainMacroQueue() {
 			Bool("is_paste", item.isPaste).
 			Msg("executing queued keyboard macro")
 
+		if isStaleQueuedMacro(item) {
+			logger.Warn().
+				Uint64("macro_id", macroID).
+				Bool("is_paste", item.isPaste).
+				Msg("discarding stale-session queued keyboard macro")
+			if item.isPaste {
+				forceKeyboardAllKeysUp("stale paste macro discard")
+				if pasteDepth.Add(-1) == 0 {
+					logger.Debug().Uint64("macro_id", macroID).Msg("paste-depth 1->0 (stale discard)")
+					emitPasteState(item.session, false, pasteFailures.Swap(0) > 0)
+				}
+			}
+			time.Sleep(pasteInterMacroDrain)
+			continue
+		}
+
 		ctx, cancel := context.WithCancel(context.Background())
 
 		macroLock.Lock()
@@ -1126,8 +1158,12 @@ func drainMacroQueue() {
 		err := rpcDoExecuteKeyboardMacro(ctx, item.steps)
 		if err != nil {
 			logger.Warn().Uint64("macro_id", macroID).Err(err).Msg("queued keyboard macro failed")
-			if item.isPaste && !errors.Is(err, context.Canceled) {
-				pasteFailures.Add(1)
+			if item.isPaste {
+				if errors.Is(err, context.Canceled) {
+					forceKeyboardAllKeysUp("canceled paste macro")
+				} else {
+					pasteFailures.Add(1)
+				}
 			}
 		} else {
 			logger.Info().Uint64("macro_id", macroID).Msg("queued keyboard macro completed")
@@ -1186,6 +1222,8 @@ func cancelAndDrainMacroQueue() {
 	}
 	macroLock.Unlock()
 
+	forceKeyboardAllKeysUp("macro queue cancel")
+
 	// Step 3: Sweep any remaining items out of the channel without running them.
 	// Track the session of the last paste item we saw so that if our sweep closes
 	// the paste session (1→0), we emit State:false to the right session.
@@ -1231,6 +1269,11 @@ func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep,
 	// Ensure queue is started (idempotent)
 	startMacroQueue()
 
+	if isPaste && isStalePasteSession(session) {
+		logger.Warn().Uint64("macro_id", macroID).Msg("rejecting stale-session paste macro")
+		return context.Canceled
+	}
+
 	// Snapshot the current enqueue cancellation context. If
 	// cancelAndDrainMacroQueue rotates the context while we're blocked on
 	// send, the snapshot we hold still fires on the old Cancel and unblocks
@@ -1265,7 +1308,11 @@ func rpcExecuteKeyboardMacro(session *Session, steps []hidrpc.KeyboardMacroStep,
 	}
 }
 
-func rpcCancelKeyboardMacro() {
+func rpcCancelKeyboardMacro(session *Session) {
+	if isStalePasteSession(session) {
+		logger.Warn().Msg("ignoring stale-session keyboard macro cancel")
+		return
+	}
 	cancelAndDrainMacroQueue()
 }
 

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -59,7 +59,7 @@ const MACRO_RESET_KEYBOARD_STATE = {
 // pastes — chunkable or not — will observe the flag having flipped
 // true during the first paste's drain messages and use chunk mode if
 // the device supports it.
-let executePasteTextInFlight = false;
+let executePasteTextInFlightChannel: RTCDataChannel | null = null;
 let pasteStateSupportObserved = false;
 let pasteStateSupportChannel: RTCDataChannel | null = null;
 let pasteFailureSequence = 0;
@@ -72,6 +72,16 @@ function syncPasteStateSupportChannel(channel: RTCDataChannel | null): boolean {
   pasteStateSupportObserved = false;
   useHidStore.getState().setPasteModeEnabled(false);
   return false;
+}
+
+function ensurePasteExecutionChannelCurrent(channel: RTCDataChannel): void {
+  if (
+    executePasteTextInFlightChannel !== channel ||
+    useRTCStore.getState().rpcHidChannel !== channel ||
+    channel.readyState !== "open"
+  ) {
+    throw new Error("Paste HID data channel changed");
+  }
 }
 
 export interface MacroStep {
@@ -665,28 +675,33 @@ export default function useKeyboard() {
 
   const executePasteText = useCallback(
     async (text: string, options: ExecutePasteTextOptions) => {
+      const {
+        keyboard,
+        delayMs,
+        maxStepsPerBatch,
+        maxBytesPerBatch,
+        finalSettleMs,
+        signal,
+        onProgress,
+        onTrace,
+      } = options;
+
+      const channel = rpcHidChannel;
+      if (!channel || channel.readyState !== "open") {
+        throw new Error("HID data channel not available");
+      }
+
       // Module-level concurrency guard. PasteModal also has a local
       // in-flight guard for UI responsiveness, but that guard dies
       // when the popover unmounts (e.g., click-outside dismissal during
-      // a chunk boundary). This flag survives component remounts and
-      // is the correctness-level guard against interleaved pastes on
-      // the same data channel.
-      if (executePasteTextInFlight) {
+      // a chunk boundary). This channel identity survives component
+      // remounts and prevents an old async paste loop from continuing
+      // after the HID channel is replaced by refresh/reconnect.
+      if (executePasteTextInFlightChannel === channel) {
         throw new Error("A paste is already in progress");
       }
-      executePasteTextInFlight = true;
+      executePasteTextInFlightChannel = channel;
       try {
-        const {
-          keyboard,
-          delayMs,
-          maxStepsPerBatch,
-          maxBytesPerBatch,
-          finalSettleMs,
-          signal,
-          onProgress,
-          onTrace,
-        } = options;
-
         const { batches, invalidChars, batchStats } = buildPasteMacroBatches(
           text,
           keyboard,
@@ -705,10 +720,6 @@ export default function useKeyboard() {
         const PASTE_LOW_WATERMARK = 64 * 1024;
         const PASTE_HIGH_WATERMARK = 256 * 1024;
 
-        const channel = rpcHidChannel;
-        if (!channel || channel.readyState !== "open") {
-          throw new Error("HID data channel not available");
-        }
         const pasteStateSupportedForChannel = syncPasteStateSupportChannel(channel);
 
         // Save and set bufferedAmount threshold for paste flow control
@@ -802,8 +813,10 @@ export default function useKeyboard() {
                 throw new Error("Paste execution aborted");
               }
 
+              ensurePasteExecutionChannelCurrent(channel);
               const batch = batches[b];
               await executePasteMacro(batch);
+              ensurePasteExecutionChannelCurrent(channel);
 
               onTrace?.({
                 kind: "batch",
@@ -827,6 +840,7 @@ export default function useKeyboard() {
               // pending promise immediately via onBufferedDrainAbort.
               if (channel.bufferedAmount >= PASTE_HIGH_WATERMARK) {
                 await waitForChannelDrain();
+                ensurePasteExecutionChannelCurrent(channel);
               }
             }
 
@@ -932,6 +946,7 @@ export default function useKeyboard() {
                   pasteFailureBaseline,
                 );
               }
+              ensurePasteExecutionChannelCurrent(channel);
               onTrace?.({
                 kind: "chunk-drained",
                 chunkIndex: chunk.chunkIndex + 1,
@@ -956,6 +971,7 @@ export default function useKeyboard() {
                   pauseMs: policy.chunkPauseMs,
                 });
                 await abortableSleep(policy.chunkPauseMs, signal);
+                ensurePasteExecutionChannelCurrent(channel);
               }
             }
           }
@@ -983,13 +999,16 @@ export default function useKeyboard() {
             pasteFailureBaseline,
             !(rpcHidReady && !chunkMode && batches.length > 0),
           );
+          ensurePasteExecutionChannelCurrent(channel);
         } finally {
           channel.removeEventListener("bufferedamountlow", onLow);
           signal?.removeEventListener("abort", onBufferedDrainAbort);
           channel.bufferedAmountLowThreshold = prevThreshold;
         }
       } finally {
-        executePasteTextInFlight = false;
+        if (executePasteTextInFlightChannel === channel) {
+          executePasteTextInFlightChannel = null;
+        }
       }
     },
     [executePasteMacro, rpcHidChannel, rpcHidReady],

--- a/web.go
+++ b/web.go
@@ -244,10 +244,13 @@ func handleWebRTCSession(c *gin.Context) {
 		}()
 	}
 
-	// Cancel any ongoing keyboard macro when session changes
+	currentSession = session
+
+	// Cancel any ongoing keyboard macro when session changes. Assigning the
+	// new current session first makes late HID messages from the old page stale
+	// immediately while queuedMacro.session still routes final paste-state emits.
 	cancelAndDrainMacroQueue()
 
-	currentSession = session
 	c.JSON(http.StatusOK, gin.H{"sd": sd})
 }
 

--- a/webrtc.go
+++ b/webrtc.go
@@ -472,9 +472,9 @@ func newSession(config SessionConfig) (*Session, error) {
 		if connectionState == webrtc.ICEConnectionStateClosed {
 			scopedLogger.Debug().Msg("ICE Connection State is closed, unmounting virtual media")
 			if session == currentSession {
+				currentSession = nil
 				// Cancel any ongoing keyboard report multi when session closes
 				cancelAndDrainMacroQueue()
-				currentSession = nil
 			}
 			// Stop RPC processor
 			if session.rpcQueue != nil {


### PR DESCRIPTION
## Summary
- force a real HID all-keys-up report during macro cancel/teardown and canceled paste macro cleanup
- reject old-session paste macro enqueues before they touch pasteDepth
- discard stale queued paste macros in the drain goroutine while preserving origin-session paste-state emits and the 200ms inter-macro pause
- scope explicit cancel messages to their origin session so late old-page cancels cannot stop a new session
- mark old sessions stale before cancel sweeps on local/cloud takeover and WebRTC close
- stop frontend paste send loops when the HID channel is replaced or closed
- add static regression coverage for the cancel/teardown invariants

Closes #55.
Closes #56.

## Verification
- `wsl.exe bash -lc "go test ./internal/regression"`
- `wsl.exe bash -lc "go test ./internal/usbgadget ./internal/regression ./internal/confparser ./internal/ota ./internal/utils ./internal/websecure"`
- `cd ui && npx tsc --noEmit`
- `cd ui && npx eslint './src/hooks/useKeyboard.ts'`
- `git diff --check` (clean aside from Windows `core.autocrlf` warnings)

## Review Notes
- GPT-5.5 xhigh frontend/backend explorer agents reviewed the shape of the #55/#56 fix.
- A GPT-5.5 xhigh code-review pass found the close-path stale-window and stale-enqueue all-keys-up race; both were fixed.
- A final GPT-5.5 xhigh review attempt hit the account usage limit, so the final pass was local source review plus the verification above.

## Limitations
- Full `go test ./internal/...` reaches the known native C artifact prerequisite and fails in `internal/native` without generated native/static C outputs.
- Full root package tests are also not runnable in this Windows worktree for the known static/native artifact reasons.
- UI dependencies were installed with local Node v24.14.1, which reports the repo's expected engine as `^22.21.1`.
## Current Blocker

GitHub Actions are green on the rebased branch. Still blocked on reachable JetKVM hardware validation. As of 2026-05-01, `jetkvm.local` does not resolve, `192.168.1.36` is unreachable on ICMP/22/80, and `192.168.1.188` rejects current `root` SSH auth.