### PR TITLE
Phase 5: frontend paste memory cleanup

### DIFF
--- a/.github/workflows/ui-lint.yml
+++ b/.github/workflows/ui-lint.yml
@@ -28,6 +28,10 @@ jobs:
         run: |
           cd ui
           npm ci
+      - name: Test UI units
+        run: |
+          cd ui
+          npm run test:unit
       - name: Lint UI
         run: |
           cd ui

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -80,7 +80,8 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.49.0",
         "vite": "^7.2.7",
-        "vite-tsconfig-paths": "^5.1.4"
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": "^22.21.1"
@@ -1749,9 +1750,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -2334,6 +2335,17 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2395,6 +2407,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2763,6 +2782,119 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-clipboard": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.1.0.tgz",
@@ -3047,6 +3179,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3252,6 +3394,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3861,6 +4013,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4460,6 +4619,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4475,6 +4644,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6155,6 +6334,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6260,6 +6450,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -7081,6 +7278,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7101,6 +7305,20 @@
       "peerDependencies": {
         "kysely": "*"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7321,6 +7539,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7335,6 +7570,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7804,6 +8049,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -7914,6 +8249,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,7 +27,9 @@
     "i18n:find-excess": "python3 ./tools/find_excess_messages.py",
     "i18n:find-unused": "python3 ./tools/find_unused_messages.py",
     "i18n:find-dupes": "python3 ./tools/find_duplicate_translations.py",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:unit": "vitest run --config vitest.config.ts",
+    "bench:paste": "vitest bench --config vitest.config.ts src/utils/pasteMacro.bench.ts --run"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",
@@ -102,6 +104,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.49.0",
     "vite": "^7.2.7",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^4.1.5"
   }
 }

--- a/ui/src/hooks/hidRpc.test.ts
+++ b/ui/src/hooks/hidRpc.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  HID_RPC_MESSAGE_TYPES,
+  KeyboardMacroReportMessage,
+  type KeyboardMacroStep,
+} from "./hidRpc";
+
+describe("KeyboardMacroReportMessage", () => {
+  test("marshals short key arrays without mutating source steps", () => {
+    const step: KeyboardMacroStep = {
+      modifier: 2,
+      keys: [4],
+      delay: 25,
+    };
+
+    const data = new KeyboardMacroReportMessage(true, 1, [step]).marshal();
+
+    expect(step.keys).toEqual([4]);
+    expect(data).toEqual(
+      new Uint8Array([
+        HID_RPC_MESSAGE_TYPES.KeyboardMacroReport,
+        1,
+        0,
+        0,
+        0,
+        1,
+        2,
+        4,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        25,
+      ]),
+    );
+  });
+
+  test("validates source keys without padding them first", () => {
+    const step: KeyboardMacroStep = {
+      modifier: 0,
+      keys: [300],
+      delay: 0,
+    };
+
+    expect(() => new KeyboardMacroReportMessage(true, 1, [step]).marshal()).toThrow(
+      "Key 300 is not within the uint8 range",
+    );
+    expect(step.keys).toEqual([300]);
+  });
+});

--- a/ui/src/hooks/hidRpc.ts
+++ b/ui/src/hooks/hidRpc.ts
@@ -31,14 +31,6 @@ const fromInt32toUint8 = (n: number) => {
   return new Uint8Array([(n >> 24) & 0xff, (n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff]);
 };
 
-const fromUint16toUint8 = (n: number) => {
-  if (n > 65535 || n < 0) {
-    throw new Error(`Number ${n} is not within the uint16 range`);
-  }
-
-  return new Uint8Array([(n >> 8) & 0xff, n & 0xff]);
-};
-
 const fromUint32toUint8 = (n: number) => {
   if (n > 4294967295 || n < 0) {
     throw new Error(`Number ${n} is not within the uint32 range`);
@@ -241,8 +233,6 @@ export class KeyboardMacroReportMessage extends RpcMessage {
       const keys = step.keys;
       if (keys.length > this.KEYS_LENGTH) {
         throw new Error(`Keys ${keys} is not within the hidKeyBufferSize range`);
-      } else if (keys.length < this.KEYS_LENGTH) {
-        keys.push(...Array(this.KEYS_LENGTH - keys.length).fill(0));
       }
 
       for (const key of keys) {
@@ -251,13 +241,16 @@ export class KeyboardMacroReportMessage extends RpcMessage {
         }
       }
 
-      const macroBinary = new Uint8Array([
-        step.modifier,
-        ...keys,
-        ...fromUint16toUint8(step.delay),
-      ]);
+      if (step.delay > 65535 || step.delay < 0) {
+        throw new Error(`Number ${step.delay} is not within the uint16 range`);
+      }
 
-      data.set(macroBinary, offset);
+      data[offset] = step.modifier;
+      for (let k = 0; k < keys.length; k++) {
+        data[offset + 1 + k] = keys[k];
+      }
+      data[offset + 7] = (step.delay >> 8) & 0xff;
+      data[offset + 8] = step.delay & 0xff;
       offset += 9;
     }
 

--- a/ui/src/utils/pasteBatches.test.ts
+++ b/ui/src/utils/pasteBatches.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+
+import { PASTE_PROFILES } from "./pasteBatches";
+import { estimateBatchBytes } from "./pasteMacro";
+
+describe("PASTE_PROFILES", () => {
+  test("keeps every step cap reachable under its byte cap", () => {
+    for (const [name, profile] of Object.entries(PASTE_PROFILES)) {
+      expect(Number.isFinite(profile.maxStepsPerBatch), name).toBe(true);
+      expect(Number.isFinite(profile.maxBytesPerBatch), name).toBe(true);
+      expect(Number.isFinite(profile.keyDelayMs), name).toBe(true);
+      expect(estimateBatchBytes(profile.maxStepsPerBatch), name).toBeLessThanOrEqual(
+        profile.maxBytesPerBatch,
+      );
+    }
+  });
+});

--- a/ui/src/utils/pasteMacro.bench.ts
+++ b/ui/src/utils/pasteMacro.bench.ts
@@ -1,0 +1,134 @@
+import { bench, describe } from "vitest";
+
+import type { MacroStep } from "@/hooks/useKeyboard";
+
+import {
+  buildPasteMacroBatches,
+  estimateBatchBytes,
+  type KeyboardLayoutLike,
+  type PasteBatchStat,
+  type PasteMacroBatchResult,
+} from "./pasteMacro";
+
+const keyboard: KeyboardLayoutLike = {
+  chars: {
+    C: { key: "KeyC", shift: true },
+    a: { key: "KeyA" },
+    f: { key: "KeyF" },
+    e: { key: "KeyE" },
+    "\u00e9": { key: "KeyE", accentKey: { key: "Quote" } },
+    A: { key: "KeyA", shift: true },
+    "@": { key: "Digit2", altRight: true },
+    "^": { key: "Equal", deadKey: true },
+  },
+};
+
+const largePaste = "Cafe\u0301A@^".repeat(2000);
+
+describe("paste macro hot path", () => {
+  bench("optimized buildPasteMacroBatches large mixed input", () => {
+    buildPasteMacroBatches(largePaste, keyboard, 7, 128, 2310);
+  });
+
+  bench("legacy buildPasteMacroBatches large mixed input", () => {
+    buildPasteMacroBatchesLegacy(largePaste, keyboard, 7, 128, 2310);
+  });
+});
+
+function buildPasteMacroBatchesLegacy(
+  text: string,
+  keyboard: KeyboardLayoutLike,
+  delay: number,
+  maxStepsPerBatch: number,
+  maxBytesPerBatch: number,
+): PasteMacroBatchResult {
+  const batches = [] as ReturnType<typeof buildPasteMacroBatches>["batches"];
+  const batchStats: PasteBatchStat[] = [];
+  const invalidChars = new Set<string>();
+  let currentBatch = [] as ReturnType<typeof buildPasteMacroBatches>["batches"][number];
+  let currentBatchSourceChars = 0;
+
+  const flushBatch = () => {
+    if (currentBatch.length === 0) return;
+    batches.push(currentBatch);
+    batchStats.push({
+      stepCount: currentBatch.length,
+      estimatedBytes: estimateBatchBytes(currentBatch.length),
+      sourceChars: currentBatchSourceChars,
+    });
+    currentBatch = [];
+    currentBatchSourceChars = 0;
+  };
+
+  for (const char of text) {
+    const normalizedChar = char.normalize("NFC");
+    const charSteps = buildStepsForCharLegacy(normalizedChar, keyboard, delay);
+    if (!charSteps) {
+      invalidChars.add(normalizedChar);
+      continue;
+    }
+
+    const projectedStepCount = currentBatch.length + charSteps.length;
+    const projectedBytes = estimateBatchBytes(projectedStepCount);
+
+    if (
+      currentBatch.length > 0 &&
+      (projectedStepCount > maxStepsPerBatch || projectedBytes > maxBytesPerBatch)
+    ) {
+      flushBatch();
+    }
+
+    currentBatch.push(...charSteps);
+    currentBatchSourceChars += 1;
+  }
+
+  flushBatch();
+
+  return {
+    batches,
+    invalidChars: Array.from(invalidChars),
+    batchStats,
+  };
+}
+
+function buildStepsForCharLegacy(
+  normalizedChar: string,
+  keyboard: KeyboardLayoutLike,
+  delay: number,
+): MacroStep[] | null {
+  const keyprops = keyboard.chars[normalizedChar];
+  if (!keyprops || !keyprops.key) {
+    return null;
+  }
+
+  const { key, shift, altRight, deadKey, accentKey } = keyprops;
+  const steps: MacroStep[] = [];
+
+  if (accentKey) {
+    const accentModifiers: string[] = [];
+    if (accentKey.shift) accentModifiers.push("ShiftLeft");
+    if (accentKey.altRight) accentModifiers.push("AltRight");
+
+    steps.push({
+      keys: [String(accentKey.key)],
+      modifiers: accentModifiers.length > 0 ? accentModifiers : null,
+      delay,
+    });
+  }
+
+  const modifiers: string[] = [];
+  if (shift) modifiers.push("ShiftLeft");
+  if (altRight) modifiers.push("AltRight");
+
+  steps.push({
+    keys: [String(key)],
+    modifiers: modifiers.length > 0 ? modifiers : null,
+    delay,
+  });
+
+  if (deadKey) {
+    steps.push({ keys: ["Space"], modifiers: null, delay });
+  }
+
+  return steps;
+}

--- a/ui/src/utils/pasteMacro.test.ts
+++ b/ui/src/utils/pasteMacro.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildPasteMacroBatches,
+  buildPasteMacroSteps,
+  type KeyboardLayoutLike,
+} from "./pasteMacro";
+
+const keyboard: KeyboardLayoutLike = {
+  chars: {
+    C: { key: "KeyC", shift: true },
+    a: { key: "KeyA" },
+    f: { key: "KeyF" },
+    e: { key: "KeyE" },
+    "\u00e9": { key: "KeyE", accentKey: { key: "Quote" } },
+    A: { key: "KeyA", shift: true },
+    "@": { key: "Digit2", altRight: true },
+    "^": { key: "Equal", deadKey: true },
+  },
+};
+
+describe("paste macro building", () => {
+  test("normalizes whole input before splitting into macro steps", () => {
+    const nfc = buildPasteMacroSteps("Caf\u00e9A@^", keyboard, 7);
+    const nfd = buildPasteMacroSteps("Cafe\u0301A@^", keyboard, 7);
+
+    expect(nfd.invalidChars).toEqual([]);
+    expect(nfd.steps).toEqual(nfc.steps);
+  });
+
+  test("normalizes whole input before splitting into batches", () => {
+    const nfc = buildPasteMacroBatches("Caf\u00e9A@^", keyboard, 7, 4, 78);
+    const nfd = buildPasteMacroBatches("Cafe\u0301A@^", keyboard, 7, 4, 78);
+
+    expect(nfd.invalidChars).toEqual([]);
+    expect(nfd.batches).toEqual(nfc.batches);
+    expect(nfd.batchStats).toEqual(nfc.batchStats);
+  });
+
+  test("reuses modifier arrays for repeated modifier combinations", () => {
+    const { steps } = buildPasteMacroSteps("AA@@", keyboard, 7);
+
+    expect(steps[0].modifiers).toEqual(["ShiftLeft"]);
+    expect(steps[0].modifiers).toBe(steps[1].modifiers);
+    expect(steps[2].modifiers).toEqual(["AltRight"]);
+    expect(steps[2].modifiers).toBe(steps[3].modifiers);
+  });
+});

--- a/ui/src/utils/pasteMacro.ts
+++ b/ui/src/utils/pasteMacro.ts
@@ -16,6 +16,17 @@ export interface KeyboardLayoutLike {
   chars: Record<string, KeyboardCharMapping | undefined>;
 }
 
+const MODS_SHIFT = Object.freeze(["ShiftLeft"]);
+const MODS_ALT_RIGHT = Object.freeze(["AltRight"]);
+const MODS_SHIFT_ALT_RIGHT = Object.freeze(["ShiftLeft", "AltRight"]);
+
+function pickModifiers(shift?: boolean, altRight?: boolean): MacroStep["modifiers"] {
+  if (shift && altRight) return MODS_SHIFT_ALT_RIGHT as string[];
+  if (shift) return MODS_SHIFT as string[];
+  if (altRight) return MODS_ALT_RIGHT as string[];
+  return null;
+}
+
 export interface PasteMacroBuildResult {
   steps: MacroStep[];
   invalidChars: string[];
@@ -55,24 +66,16 @@ export function buildStepsForChar(
   const steps: MacroStep[] = [];
 
   if (accentKey) {
-    const accentModifiers: string[] = [];
-    if (accentKey.shift) accentModifiers.push("ShiftLeft");
-    if (accentKey.altRight) accentModifiers.push("AltRight");
-
     steps.push({
       keys: [String(accentKey.key)],
-      modifiers: accentModifiers.length > 0 ? accentModifiers : null,
+      modifiers: pickModifiers(accentKey.shift, accentKey.altRight),
       delay,
     });
   }
 
-  const modifiers: string[] = [];
-  if (shift) modifiers.push("ShiftLeft");
-  if (altRight) modifiers.push("AltRight");
-
   steps.push({
     keys: [String(key)],
-    modifiers: modifiers.length > 0 ? modifiers : null,
+    modifiers: pickModifiers(shift, altRight),
     delay,
   });
 
@@ -90,16 +93,18 @@ export function buildPasteMacroSteps(
 ): PasteMacroBuildResult {
   const steps: MacroStep[] = [];
   const invalidChars = new Set<string>();
+  const normalizedText = text.normalize("NFC");
 
-  for (const char of text) {
-    const normalizedChar = char.normalize("NFC");
-    const charSteps = buildStepsForChar(normalizedChar, keyboard, delay);
+  for (const char of normalizedText) {
+    const charSteps = buildStepsForChar(char, keyboard, delay);
     if (!charSteps) {
-      invalidChars.add(normalizedChar);
+      invalidChars.add(char);
       continue;
     }
 
-    steps.push(...charSteps);
+    for (const step of charSteps) {
+      steps.push(step);
+    }
   }
 
   return {
@@ -127,6 +132,7 @@ export function buildPasteMacroBatches(
   const invalidChars = new Set<string>();
   let currentBatch: MacroStep[] = [];
   let currentBatchSourceChars = 0;
+  const normalizedText = text.normalize("NFC");
 
   const flushBatch = () => {
     if (currentBatch.length === 0) return;
@@ -140,11 +146,10 @@ export function buildPasteMacroBatches(
     currentBatchSourceChars = 0;
   };
 
-  for (const char of text) {
-    const normalizedChar = char.normalize("NFC");
-    const charSteps = buildStepsForChar(normalizedChar, keyboard, delay);
+  for (const char of normalizedText) {
+    const charSteps = buildStepsForChar(char, keyboard, delay);
     if (!charSteps) {
-      invalidChars.add(normalizedChar);
+      invalidChars.add(char);
       continue;
     }
 
@@ -158,7 +163,9 @@ export function buildPasteMacroBatches(
       flushBatch();
     }
 
-    currentBatch.push(...charSteps);
+    for (const step of charSteps) {
+      currentBatch.push(step);
+    }
     currentBatchSourceChars += 1;
   }
 

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -21,11 +21,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "allowSyntheticDefaultImports": true,
-    "composite": true,
+    "composite": true
   },
-  "include": [
-    "vite.config.ts",
-    "playwright.config.ts",
-    "e2e/**/*.ts"
-  ]
+  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts", "e2e/**/*.ts"]
 }

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["e2e/**"],
+  },
+});


### PR DESCRIPTION
## Summary
- Add a Vitest unit-test harness and wire it into the UI CI workflow before lint.
- Cover paste macro normalization, batch byte-cap invariants, and HID macro marshaling behavior.
- Reduce frontend paste hot-path churn by normalizing the full input once, reusing modifier arrays, avoiding spread pushes, and writing HID macro bytes without padding/mutating source steps.

## Verification
- `npm run test:unit` (3 files, 6 tests)
- `npx tsc --noEmit`
- `npx eslint './src/utils/pasteMacro.ts' './src/utils/pasteMacro.test.ts' './src/hooks/hidRpc.ts' './src/hooks/hidRpc.test.ts' './src/utils/pasteBatches.test.ts' './src/utils/pasteMacro.bench.ts'`
- `npm run bench:paste` (optimized path 2.61x faster than local legacy benchmark)
- `git diff --check` (exit 0; expected Windows CRLF working-copy warnings only)

## Notes
- Full UI lint remains unsuitable as a pass/fail signal on this Windows checkout because AGENTS.md documents the existing CRLF/prettier baseline artifact; this PR uses targeted lint for the touched source and test files.
- `npm install --save-dev vitest` emitted the existing npm audit/engine noise in this checkout (`package.json` wants Node ^22.21.1, local Node is v24.14.1).

Closes #45