### PR TITLE
fix(paste): batch HID sequence writes

### DIFF
--- a/internal/regression/jsonrpc_timer_reuse_test.go
+++ b/internal/regression/jsonrpc_timer_reuse_test.go
@@ -8,16 +8,16 @@ import (
 	"testing"
 )
 
-func TestRPCDoExecuteKeyboardMacroDoesNotAllocateTimerPerStep(t *testing.T) {
+func TestRPCDoExecuteKeyboardMacroLoopDoesNotAllocateTimerPerStep(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, filepath.Join("..", "..", "jsonrpc.go"), nil, 0)
 	if err != nil {
 		t.Fatalf("parse jsonrpc.go: %v", err)
 	}
 
-	fn := findFunc(file, "rpcDoExecuteKeyboardMacro")
+	fn := findFunc(file, "rpcDoExecuteKeyboardMacroStepLoop")
 	if fn == nil {
-		t.Fatal("rpcDoExecuteKeyboardMacro not found")
+		t.Fatal("rpcDoExecuteKeyboardMacroStepLoop not found")
 	}
 
 	var newTimerCalls []token.Position
@@ -32,7 +32,7 @@ func TestRPCDoExecuteKeyboardMacroDoesNotAllocateTimerPerStep(t *testing.T) {
 		return true
 	})
 	if len(newTimerCalls) != 1 {
-		t.Fatalf("rpcDoExecuteKeyboardMacro should allocate exactly one reusable timer, found %d at %v", len(newTimerCalls), newTimerCalls)
+		t.Fatalf("rpcDoExecuteKeyboardMacroStepLoop should allocate exactly one reusable timer, found %d at %v", len(newTimerCalls), newTimerCalls)
 	}
 
 	loop := findRangeLoop(fn.Body)
@@ -54,7 +54,24 @@ func TestRPCDoExecuteKeyboardMacroDoesNotAllocateTimerPerStep(t *testing.T) {
 		return true
 	})
 	if len(perStepDelayCalls) > 0 {
-		t.Fatalf("rpcDoExecuteKeyboardMacro allocates or blocks with time package calls inside its step loop; use the reusable timer instead: %v", perStepDelayCalls)
+		t.Fatalf("rpcDoExecuteKeyboardMacroStepLoop allocates or blocks with time package calls inside its step loop; use the reusable timer instead: %v", perStepDelayCalls)
+	}
+}
+
+func TestRPCDoExecuteKeyboardMacroUsesSequenceWriterForPasteOnly(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filepath.Join("..", "..", "jsonrpc.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse jsonrpc.go: %v", err)
+	}
+
+	fn := findFunc(file, "rpcDoExecuteKeyboardMacro")
+	if fn == nil {
+		t.Fatal("rpcDoExecuteKeyboardMacro not found")
+	}
+
+	if !hasPasteOnlySequenceBranch(fn.Body) {
+		t.Fatal("rpcDoExecuteKeyboardMacro should dispatch isPaste macros to rpcDoExecutePasteKeyboardMacro and otherwise use rpcDoExecuteKeyboardMacroStepLoop")
 	}
 }
 
@@ -90,4 +107,39 @@ func isSelector(expr ast.Expr, pkgName, selectorName string) bool {
 	}
 	ident, ok := selector.X.(*ast.Ident)
 	return ok && ident.Name == pkgName && selector.Sel.Name == selectorName
+}
+
+func hasPasteOnlySequenceBranch(body *ast.BlockStmt) bool {
+	var ifStmt *ast.IfStmt
+	var ifIndex int
+	for i, stmt := range body.List {
+		candidate, ok := stmt.(*ast.IfStmt)
+		if ok && isIdent(candidate.Cond, "isPaste") {
+			ifStmt = candidate
+			ifIndex = i
+			break
+		}
+	}
+	if ifStmt == nil || ifIndex+1 >= len(body.List) {
+		return false
+	}
+
+	if len(ifStmt.Body.List) != 1 {
+		return false
+	}
+	pasteReturn, ok := ifStmt.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(pasteReturn.Results) != 1 {
+		return false
+	}
+	pasteCall, ok := pasteReturn.Results[0].(*ast.CallExpr)
+	if !ok || !isIdent(pasteCall.Fun, "rpcDoExecutePasteKeyboardMacro") {
+		return false
+	}
+
+	loopReturn, ok := body.List[ifIndex+1].(*ast.ReturnStmt)
+	if !ok || len(loopReturn.Results) != 1 {
+		return false
+	}
+	loopCall, ok := loopReturn.Results[0].(*ast.CallExpr)
+	return ok && isIdent(loopCall.Fun, "rpcDoExecuteKeyboardMacroStepLoop")
 }

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -314,6 +314,41 @@ func (u *UsbGadget) OpenKeyboardHidFile() error {
 
 var keyboardWriteHidFileLock sync.Mutex
 
+const keyboardReportBufferSize = 2 + hidKeyBufferSize
+
+// KeyboardHidReport is one fully padded USB HID keyboard report plus the delay
+// that must elapse after the report is written.
+type KeyboardHidReport struct {
+	Modifier   byte
+	Keys       [hidKeyBufferSize]byte
+	DelayAfter time.Duration
+}
+
+// NewKeyboardHidReport pads or truncates keys to the HID keyboard report size.
+func NewKeyboardHidReport(modifier byte, keys []byte, delayAfter time.Duration) KeyboardHidReport {
+	report := KeyboardHidReport{
+		Modifier:   modifier,
+		DelayAfter: delayAfter,
+	}
+	copy(report.Keys[:], keys)
+	return report
+}
+
+// KeyboardSequencePartialWriteError reports how many HID reports reached the
+// host before a sequence write failed.
+type KeyboardSequencePartialWriteError struct {
+	Completed int
+	Err       error
+}
+
+func (e *KeyboardSequencePartialWriteError) Error() string {
+	return fmt.Sprintf("keyboard HID sequence failed after %d completed writes: %v", e.Completed, e.Err)
+}
+
+func (e *KeyboardSequencePartialWriteError) Unwrap() error {
+	return e.Err
+}
+
 func (u *UsbGadget) keyboardWriteHidFile(modifier byte, keys []byte) error {
 	keyboardWriteHidFileLock.Lock()
 	defer keyboardWriteHidFileLock.Unlock()
@@ -329,6 +364,125 @@ func (u *UsbGadget) keyboardWriteHidFile(modifier byte, keys []byte) error {
 		return err
 	}
 	u.resetLogSuppressionCounter("keyboardWriteHidFile")
+	return nil
+}
+
+func (u *UsbGadget) keyboardWriteHidReportToOpenFileLocked(report KeyboardHidReport, buf *[keyboardReportBufferSize]byte) error {
+	buf[0] = report.Modifier
+	buf[1] = 0x00
+	copy(buf[2:], report.Keys[:])
+	_, err := u.writeWithTimeout(u.keyboardHidFile, buf[:])
+	if err != nil {
+		u.logWithSuppression("keyboardWriteHidFile", 100, u.log, err, "failed to write to hidg0")
+		u.keyboardHidFile.Close()
+		u.keyboardHidFile = nil
+		return err
+	}
+	u.resetLogSuppressionCounter("keyboardWriteHidFile")
+	return nil
+}
+
+func isClearKeyboardHidReport(report KeyboardHidReport) bool {
+	if report.Modifier != 0 {
+		return false
+	}
+	for _, key := range report.Keys {
+		if key != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (u *UsbGadget) clearKeyboardHidReportLocked(buf *[keyboardReportBufferSize]byte) {
+	clearReport := NewKeyboardHidReport(0, nil, 0)
+	err := u.keyboardWriteHidReportToOpenFileLocked(clearReport, buf)
+	u.RecordWriteResult(err)
+	if err != nil {
+		u.log.Warn().Err(err).Msg("failed to reset keyboard state during sequence cancellation")
+		return
+	}
+	u.UpdateKeysDown(clearReport.Modifier, clearReport.Keys[:])
+	u.resetUserInputTime()
+}
+
+// KeyboardHidReportSequence writes a paste macro as one timed sequence. It
+// preserves per-report delays while holding the write lock across the sequence,
+// preventing other keyboard reports from interleaving mid-paste.
+func (u *UsbGadget) KeyboardHidReportSequence(ctx context.Context, reports []KeyboardHidReport) error {
+	defer u.resetUserInputTime()
+	if len(reports) == 0 {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	keyboardWriteHidFileLock.Lock()
+	defer keyboardWriteHidFileLock.Unlock()
+
+	var buf [keyboardReportBufferSize]byte
+	if err := u.openKeyboardHidFile(); err != nil {
+		u.RecordWriteResult(err)
+		return err
+	}
+
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	defer timer.Stop()
+
+	wroteReport := false
+	lastReportClear := true
+	for i, report := range reports {
+		if err := ctx.Err(); err != nil {
+			if wroteReport && !lastReportClear {
+				u.clearKeyboardHidReportLocked(&buf)
+			}
+			return err
+		}
+
+		err := u.keyboardWriteHidReportToOpenFileLocked(report, &buf)
+		u.RecordWriteResult(err)
+		if err != nil {
+			u.log.Warn().
+				Uint8("modifier", report.Modifier).
+				Uints8("keys", report.Keys[:]).
+				Msg("Could not write keyboard report sequence item to hidg0")
+			return &KeyboardSequencePartialWriteError{Completed: i, Err: err}
+		}
+
+		u.UpdateKeysDown(report.Modifier, report.Keys[:])
+		u.resetUserInputTime()
+		wroteReport = true
+		lastReportClear = isClearKeyboardHidReport(report)
+
+		if report.DelayAfter <= 0 {
+			continue
+		}
+
+		timer.Reset(report.DelayAfter)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+
+			if !lastReportClear {
+				u.clearKeyboardHidReportLocked(&buf)
+			}
+			return ctx.Err()
+		}
+	}
+
 	return nil
 }
 

--- a/internal/usbgadget/hid_keyboard_sequence_test.go
+++ b/internal/usbgadget/hid_keyboard_sequence_test.go
@@ -1,0 +1,421 @@
+package usbgadget
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestKeyboardHidReportSequenceWritesReportsAndUpdatesFinalState(t *testing.T) {
+	g := NewUsbGadget("test", &Devices{Keyboard: true}, nil, nil)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+	g.keyboardHidFile = writer
+
+	reports := []KeyboardHidReport{
+		NewKeyboardHidReport(ModifierMaskLeftShift, []byte{0x04}, time.Millisecond),
+		NewKeyboardHidReport(0, []byte{0, 0, 0, 0, 0, 0}, 0),
+	}
+
+	gotCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		got := make([]byte, 16)
+		_, err := io.ReadFull(reader, got)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		gotCh <- got
+	}()
+
+	if err := g.KeyboardHidReportSequence(context.Background(), reports); err != nil {
+		t.Fatalf("KeyboardHidReportSequence returned error: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("read sequence bytes: %v", err)
+	case got := <-gotCh:
+		want := []byte{
+			ModifierMaskLeftShift, 0, 0x04, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("sequence bytes mismatch:\n got %v\nwant %v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading sequence bytes")
+	}
+
+	state := g.GetKeysDownState()
+	if state.Modifier != 0 || !reflect.DeepEqual([]byte(state.Keys), []byte{0, 0, 0, 0, 0, 0}) {
+		t.Fatalf("final keysDown state mismatch: %+v", state)
+	}
+}
+
+func TestKeyboardHidReportSequenceCancelsDelayWithClearReport(t *testing.T) {
+	g := NewUsbGadget("test", &Devices{Keyboard: true}, nil, nil)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+	g.keyboardHidFile = writer
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstReport := make(chan []byte, 1)
+	clearReport := make(chan []byte, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		first := make([]byte, 8)
+		if _, err := io.ReadFull(reader, first); err != nil {
+			readErr <- err
+			return
+		}
+		firstReport <- first
+		cancel()
+
+		clear := make([]byte, 8)
+		if _, err := io.ReadFull(reader, clear); err != nil {
+			readErr <- err
+			return
+		}
+		clearReport <- clear
+	}()
+
+	reports := []KeyboardHidReport{
+		NewKeyboardHidReport(ModifierMaskLeftShift, []byte{0x04}, time.Hour),
+		NewKeyboardHidReport(0, []byte{0, 0, 0, 0, 0, 0}, 0),
+	}
+	err = g.KeyboardHidReportSequence(ctx, reports)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	select {
+	case err := <-readErr:
+		t.Fatalf("read report: %v", err)
+	case got := <-firstReport:
+		want := []byte{ModifierMaskLeftShift, 0, 0x04, 0, 0, 0, 0, 0}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("first report mismatch:\n got %v\nwant %v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading first report")
+	}
+
+	select {
+	case err := <-readErr:
+		t.Fatalf("read clear report: %v", err)
+	case got := <-clearReport:
+		want := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("clear report mismatch:\n got %v\nwant %v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading clear report")
+	}
+
+	state := g.GetKeysDownState()
+	if state.Modifier != 0 || !reflect.DeepEqual([]byte(state.Keys), []byte{0, 0, 0, 0, 0, 0}) {
+		t.Fatalf("final keysDown state mismatch: %+v", state)
+	}
+}
+
+func TestKeyboardHidReportSequenceCancelsBeforeNextReportWithClearReport(t *testing.T) {
+	g := NewUsbGadget("test", &Devices{Keyboard: true}, nil, nil)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+	g.keyboardHidFile = writer
+
+	ctx := &cancelAfterErrChecksContext{nilErrs: 2}
+	gotCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		got := make([]byte, 16)
+		_, err := io.ReadFull(reader, got)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		gotCh <- got
+	}()
+
+	err = g.KeyboardHidReportSequence(ctx, []KeyboardHidReport{
+		NewKeyboardHidReport(ModifierMaskLeftShift, []byte{0x04}, 0),
+		NewKeyboardHidReport(ModifierMaskLeftShift, []byte{0x05}, 0),
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("read reports: %v", err)
+	case got := <-gotCh:
+		want := []byte{
+			ModifierMaskLeftShift, 0, 0x04, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("cancel boundary reports mismatch:\n got %v\nwant %v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading cancel boundary reports")
+	}
+
+	state := g.GetKeysDownState()
+	if state.Modifier != 0 || !reflect.DeepEqual([]byte(state.Keys), []byte{0, 0, 0, 0, 0, 0}) {
+		t.Fatalf("final keysDown state mismatch: %+v", state)
+	}
+}
+
+func TestKeyboardHidReportSequencePreservesDelayBetweenReports(t *testing.T) {
+	g := NewUsbGadget("test", &Devices{Keyboard: true}, nil, nil)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+	g.keyboardHidFile = writer
+
+	reportTimes := make(chan time.Time, 2)
+	readErr := make(chan error, 1)
+	go func() {
+		for i := 0; i < 2; i++ {
+			report := make([]byte, 8)
+			if _, err := io.ReadFull(reader, report); err != nil {
+				readErr <- err
+				return
+			}
+			reportTimes <- time.Now()
+		}
+	}()
+
+	const delay = 25 * time.Millisecond
+	err = g.KeyboardHidReportSequence(context.Background(), []KeyboardHidReport{
+		NewKeyboardHidReport(ModifierMaskLeftShift, []byte{0x04}, delay),
+		NewKeyboardHidReport(0, []byte{0, 0, 0, 0, 0, 0}, 0),
+	})
+	if err != nil {
+		t.Fatalf("KeyboardHidReportSequence returned error: %v", err)
+	}
+
+	var first, second time.Time
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-readErr:
+			t.Fatalf("read report: %v", err)
+		case ts := <-reportTimes:
+			if i == 0 {
+				first = ts
+			} else {
+				second = ts
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out reading timed reports")
+		}
+	}
+
+	if elapsed := second.Sub(first); elapsed < delay/2 {
+		t.Fatalf("reports were written too close together: elapsed %s, expected at least %s", elapsed, delay/2)
+	}
+}
+
+func TestKeyboardHidReportSequencePreventsKeyboardReportInterleaving(t *testing.T) {
+	g := NewUsbGadget("test", &Devices{Keyboard: true}, nil, nil)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+	g.keyboardHidFile = writer
+
+	gotCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		first := make([]byte, 8)
+		if _, err := io.ReadFull(reader, first); err != nil {
+			errCh <- err
+			return
+		}
+
+		keyboardWriteDone := make(chan error, 1)
+		go func() {
+			keyboardWriteDone <- g.keyboardWriteHidFile(0, []byte{0x06, 0, 0, 0, 0, 0})
+		}()
+
+		rest := make([]byte, 16)
+		if _, err := io.ReadFull(reader, rest); err != nil {
+			errCh <- err
+			return
+		}
+		if err := <-keyboardWriteDone; err != nil {
+			errCh <- err
+			return
+		}
+		gotCh <- append(first, rest...)
+	}()
+
+	err = g.KeyboardHidReportSequence(context.Background(), []KeyboardHidReport{
+		NewKeyboardHidReport(ModifierMaskLeftShift, []byte{0x04}, 25*time.Millisecond),
+		NewKeyboardHidReport(0, []byte{0, 0, 0, 0, 0, 0}, 0),
+	})
+	if err != nil {
+		t.Fatalf("KeyboardHidReportSequence returned error: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("read reports: %v", err)
+	case got := <-gotCh:
+		want := []byte{
+			ModifierMaskLeftShift, 0, 0x04, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0x06, 0, 0, 0, 0, 0,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("interleaved report order mismatch:\n got %v\nwant %v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out reading interleaving reports")
+	}
+}
+
+func TestKeyboardHidReportSequenceDoesNotUpdateKeysDownOnFailedFirstWrite(t *testing.T) {
+	g := NewUsbGadget("test", &Devices{Keyboard: true}, nil, nil)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	reader.Close()
+	defer writer.Close()
+	g.keyboardHidFile = writer
+
+	err = g.KeyboardHidReportSequence(context.Background(), []KeyboardHidReport{
+		NewKeyboardHidReport(ModifierMaskLeftShift, []byte{0x04}, 0),
+	})
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+
+	var partial *KeyboardSequencePartialWriteError
+	if !errors.As(err, &partial) {
+		t.Fatalf("expected KeyboardSequencePartialWriteError, got %T: %v", err, err)
+	}
+	if partial.Completed != 0 {
+		t.Fatalf("expected no completed writes, got %d", partial.Completed)
+	}
+
+	state := g.GetKeysDownState()
+	if state.Modifier != 0 || !reflect.DeepEqual([]byte(state.Keys), []byte{0, 0, 0, 0, 0, 0}) {
+		t.Fatalf("keysDown state should remain clear after failed first write: %+v", state)
+	}
+}
+
+type cancelAfterErrChecksContext struct {
+	nilErrs int
+}
+
+func (c *cancelAfterErrChecksContext) Deadline() (time.Time, bool) {
+	return time.Time{}, false
+}
+
+func (c *cancelAfterErrChecksContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (c *cancelAfterErrChecksContext) Err() error {
+	if c.nilErrs > 0 {
+		c.nilErrs--
+		return nil
+	}
+	return context.Canceled
+}
+
+func (c *cancelAfterErrChecksContext) Value(key any) any {
+	return nil
+}
+
+func BenchmarkKeyboardHidReportSequence(b *testing.B) {
+	g := newBenchmarkKeyboardGadget(b)
+	reports := benchmarkKeyboardReports()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := g.KeyboardHidReportSequence(context.Background(), reports); err != nil {
+			b.Fatalf("KeyboardHidReportSequence: %v", err)
+		}
+	}
+}
+
+func BenchmarkKeyboardReportLoop(b *testing.B) {
+	g := newBenchmarkKeyboardGadget(b)
+	reports := benchmarkKeyboardReports()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, report := range reports {
+			if err := g.KeyboardReport(report.Modifier, report.Keys[:]); err != nil {
+				b.Fatalf("KeyboardReport: %v", err)
+			}
+		}
+	}
+}
+
+func newBenchmarkKeyboardGadget(b *testing.B) *UsbGadget {
+	b.Helper()
+
+	g := NewUsbGadget("test", &Devices{Keyboard: true}, nil, nil)
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		b.Fatalf("create pipe: %v", err)
+	}
+	g.keyboardHidFile = writer
+
+	drained := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, reader)
+		close(drained)
+	}()
+
+	b.Cleanup(func() {
+		writer.Close()
+		reader.Close()
+		<-drained
+	})
+
+	return g
+}
+
+func benchmarkKeyboardReports() []KeyboardHidReport {
+	reports := make([]KeyboardHidReport, 0, 64)
+	for i := 0; i < 32; i++ {
+		key := byte(0x04 + i%26)
+		reports = append(reports,
+			NewKeyboardHidReport(ModifierMaskLeftShift, []byte{key}, 0),
+			NewKeyboardHidReport(0, []byte{0, 0, 0, 0, 0, 0}, 0),
+		)
+	}
+	return reports
+}

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1123,7 +1123,7 @@ func drainMacroQueue() {
 		macroCurrentCancel = cancel
 		macroLock.Unlock()
 
-		err := rpcDoExecuteKeyboardMacro(ctx, item.steps)
+		err := rpcDoExecuteKeyboardMacro(ctx, item.steps, item.isPaste)
 		if err != nil {
 			logger.Warn().Uint64("macro_id", macroID).Err(err).Msg("queued keyboard macro failed")
 			if item.isPaste && !errors.Is(err, context.Canceled) {
@@ -1276,9 +1276,29 @@ func isClearKeyStep(step hidrpc.KeyboardMacroStep) bool {
 	return step.Modifier == 0 && bytes.Equal(step.Keys, keyboardClearStateKeys)
 }
 
-func rpcDoExecuteKeyboardMacro(ctx context.Context, macro []hidrpc.KeyboardMacroStep) error {
+func rpcDoExecuteKeyboardMacro(ctx context.Context, macro []hidrpc.KeyboardMacroStep, isPaste bool) error {
 	logger.Debug().Interface("macro", macro).Msg("Executing keyboard macro")
 
+	if isPaste {
+		return rpcDoExecutePasteKeyboardMacro(ctx, macro)
+	}
+	return rpcDoExecuteKeyboardMacroStepLoop(ctx, macro)
+}
+
+func rpcDoExecutePasteKeyboardMacro(ctx context.Context, macro []hidrpc.KeyboardMacroStep) error {
+	reports := make([]usbgadget.KeyboardHidReport, 0, len(macro))
+	for _, step := range macro {
+		reports = append(reports, usbgadget.NewKeyboardHidReport(
+			step.Modifier,
+			step.Keys,
+			time.Duration(step.Delay)*time.Millisecond,
+		))
+	}
+
+	return gadget.KeyboardHidReportSequence(ctx, reports)
+}
+
+func rpcDoExecuteKeyboardMacroStepLoop(ctx context.Context, macro []hidrpc.KeyboardMacroStep) error {
 	timer := time.NewTimer(time.Hour)
 	if !timer.Stop() {
 		select {


### PR DESCRIPTION
## Summary
- Adds a paste-only timed HID sequence writer that holds the keyboard write lock across a paste macro, opens hidg0 once, and reuses one report buffer.
- Routes only `isPaste` macros through the sequence writer; non-paste macros keep the existing per-step loop and `KeyboardReport` path.
- Preserves per-step delays, sends a clear report on cancellation, and keeps `KeysDown` updates behind successful writes.

## Stack
- Replacement for closed stacked PR #64 after PR #60 merged and its base branch was deleted.
- Rebased directly onto `main`; the already-merged #60 commit was skipped during rebase.

Closes #44.

## Verification
- `wsl.exe bash -lc "cd '/mnt/c/Users/Rober/.config/superpowers/worktrees/JetKVM/issue-44-hid-sequence-writer' && go test -count=1 ./internal/usbgadget ./internal/regression ./internal/confparser ./internal/ota ./internal/utils ./internal/websecure"`
- `wsl.exe bash -lc "cd '/mnt/c/Users/Rober/.config/superpowers/worktrees/JetKVM/issue-44-hid-sequence-writer' && go test -race -count=1 ./internal/usbgadget ./internal/regression"`
- `wsl.exe bash -lc "cd '/mnt/c/Users/Rober/.config/superpowers/worktrees/JetKVM/issue-44-hid-sequence-writer' && go test ./internal/usbgadget -run '^$' -bench 'BenchmarkKeyboard(HidReportSequence|ReportLoop)$' -benchmem"`
  - sequence: `228159 ns/op`, `14730 B/op`, `67 allocs/op`
  - old loop: `259295 ns/op`, `14389 B/op`, `128 allocs/op`
- `git diff --check`

## Review Notes
- GPT-5.5 xhigh sidecar review found a cancellation-boundary bug; fixed by clearing when cancellation is observed after a non-clear report.
- Follow-up GPT-5.5 xhigh re-review found no blocking issue in the cancellation fix; adjusted the interleaving test to avoid surfacing an unrelated existing `lastUserInput` race.

## Not Covered Locally
- Device HID/LED-state validation still needs hardware: long paste, Caps/Num Lock during paste, mid-paste cancel, then manual typing to confirm no stuck modifiers.
- `golangci-lint` binary is not available locally in this Windows/WSL environment; CI remains the lint source for this branch.
## Current Blocker

GitHub Actions are green on the rebased branch. Still blocked on reachable JetKVM hardware validation. As of 2026-05-01, `jetkvm.local` does not resolve, `192.168.1.36` is unreachable on ICMP/22/80, and `192.168.1.188` rejects current `root` SSH auth.