### PR TITLE
style(ui): fix stores lint baseline

### DIFF
--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -486,7 +486,13 @@ export interface KeysDownState {
   keys: number[];
 }
 
-export type USBStates = "configured" | "attached" | "not attached" | "suspended" | "addressed" | "unknown";
+export type USBStates =
+  | "configured"
+  | "attached"
+  | "not attached"
+  | "suspended"
+  | "addressed"
+  | "unknown";
 
 export interface HidState {
   keyboardLedState: KeyboardLedState;


### PR DESCRIPTION
﻿## Summary
- Format the `USBStates` union to match the repository prettier output.
- Removes the current `stores.ts` error from the UI Lint baseline so paste PR CI reports only the existing warnings.

## Verification
- WSL/LF temp checkout: `cd ui && npm run lint` (0 errors, existing 2 warnings)
- Windows worktree: `cd ui && npx tsc --noEmit --pretty false`
- Windows worktree: `cd ui && npm run test:unit` (3 files, 6 tests)
- `git diff --check`
